### PR TITLE
Disable CET enforcement

### DIFF
--- a/src/Ryujinx/Ryujinx.csproj
+++ b/src/Ryujinx/Ryujinx.csproj
@@ -11,6 +11,7 @@
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <DefaultItemExcludes>$(DefaultItemExcludes);._*</DefaultItemExcludes>
+    <CETCompat>false</CETCompat>
   </PropertyGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="$([MSBuild]::IsOSPlatform('OSX'))">


### PR DESCRIPTION
Since canary build 1.2.97 when the project was moved to .NET 9 (ref: https://github.com/GreemDev/Ryujinx/commit/ff6628149d60663d55894ecccda00efcb306c19d), Ryujinx has been failing to launch. The cause is the "[Control-flow Enforcement Technology Shadow Stack (.NET 9+)](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/security#control-flow-enforcement-technology-shadow-stack-net-9)" feature introduced in .NET 9


*This specifically affects Windows 10, and more specifically an install of Windows 10 that is not _fully_ up-to-date*


This fix allows (Windows 10) systems that are not completely up to date as of the current .NET 9 runtime release to launch Ryujinx. Without this fix the user will receive the following output and an application crash:

> CLR: Assert failure(PID 10616 [0x00002978], Thread: 11424 [0x2ca0]): !AreShadowStacksEnabled() || UseSpecialUserModeApc()
> File: D:\a\_work\1\s\src\coreclr\vm\threads.cpp:7938
> Image: Ryujinx.exe


Possible fixes to this issue:

1. User updates their system on top of installing the .NET 9 runtime
2. ~~User disables Control-Flow Guard exploit protection in the Exploit Protection section of the Windows Security applet~~
3. Merge this pull request to disable CET enforcement by Ryujinx


refs:

https://github.com/dotnet/runtime/issues/108589
https://github.com/dotnet/docs/issues/42600
https://learn.microsoft.com/en-us/dotnet/core/compatibility/interop/9.0/cet-support
https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/security#control-flow-enforcement-technology-shadow-stack-net-9


edit: 

Disabling CFG exploit protection _**does not**_ allow Ryujinx to launch with CET enforcement enabled