### PR TITLE
UI: Option to automatically Hide UI when game launches

### DIFF
--- a/src/Ryujinx.UI.Common/Configuration/ConfigurationFileFormat.cs
+++ b/src/Ryujinx.UI.Common/Configuration/ConfigurationFileFormat.cs
@@ -17,7 +17,7 @@ namespace Ryujinx.UI.Common.Configuration
         /// <summary>
         /// The current version of the file format
         /// </summary>
-        public const int CurrentVersion = 57;
+        public const int CurrentVersion = 58;
 
         /// <summary>
         /// Version of the configuration file format
@@ -350,6 +350,11 @@ namespace Ryujinx.UI.Common.Configuration
         /// Start games in fullscreen mode
         /// </summary>
         public bool StartFullscreen { get; set; }
+
+        /// <summary>
+        /// Start games with UI hidden
+        /// </summary>
+        public bool StartNoUI { get; set; }
 
         /// <summary>
         /// Show console window

--- a/src/Ryujinx.UI.Common/Configuration/ConfigurationState.Migration.cs
+++ b/src/Ryujinx.UI.Common/Configuration/ConfigurationState.Migration.cs
@@ -640,7 +640,7 @@ namespace Ryujinx.UI.Common.Configuration
 
             if (configurationFileFormat.Version < 58)
             {
-                Ryujinx.Common.Logging.Logger.Warning?.Print(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 17.");
+                Ryujinx.Common.Logging.Logger.Warning?.Print(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 58.");
 
                 configurationFileFormat.StartNoUI = false;
 

--- a/src/Ryujinx.UI.Common/Configuration/ConfigurationState.Migration.cs
+++ b/src/Ryujinx.UI.Common/Configuration/ConfigurationState.Migration.cs
@@ -638,6 +638,15 @@ namespace Ryujinx.UI.Common.Configuration
                 configurationFileUpdated = true;
             }
 
+            if (configurationFileFormat.Version < 58)
+            {
+                Ryujinx.Common.Logging.Logger.Warning?.Print(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 17.");
+
+                configurationFileFormat.StartNoUI = false;
+
+                configurationFileUpdated = true;
+            }
+
             Logger.EnableFileLog.Value = configurationFileFormat.EnableFileLog;
             Graphics.ResScale.Value = configurationFileFormat.ResScale;
             Graphics.ResScaleCustom.Value = configurationFileFormat.ResScaleCustom;
@@ -719,6 +728,7 @@ namespace Ryujinx.UI.Common.Configuration
             UI.GridSize.Value = configurationFileFormat.GridSize;
             UI.ApplicationSort.Value = configurationFileFormat.ApplicationSort;
             UI.StartFullscreen.Value = configurationFileFormat.StartFullscreen;
+            UI.StartNoUI.Value = configurationFileFormat.StartNoUI;
             UI.ShowConsole.Value = configurationFileFormat.ShowConsole;
             UI.WindowStartup.WindowSizeWidth.Value = configurationFileFormat.WindowStartup.WindowSizeWidth;
             UI.WindowStartup.WindowSizeHeight.Value = configurationFileFormat.WindowStartup.WindowSizeHeight;

--- a/src/Ryujinx.UI.Common/Configuration/ConfigurationState.Model.cs
+++ b/src/Ryujinx.UI.Common/Configuration/ConfigurationState.Model.cs
@@ -150,6 +150,11 @@ namespace Ryujinx.UI.Common.Configuration
             public ReactiveObject<bool> StartFullscreen { get; private set; }
 
             /// <summary>
+            /// Start games with UI hidden
+            /// </summary>
+            public ReactiveObject<bool> StartNoUI { get; private set; }
+
+            /// <summary>
             /// Hide / Show Console Window
             /// </summary>
             public ReactiveObject<bool> ShowConsole { get; private set; }
@@ -189,6 +194,7 @@ namespace Ryujinx.UI.Common.Configuration
                 WindowStartup = new WindowStartupSettings();
                 BaseStyle = new ReactiveObject<string>();
                 StartFullscreen = new ReactiveObject<bool>();
+                StartNoUI = new ReactiveObject<bool>();
                 GameListViewMode = new ReactiveObject<int>();
                 ShowNames = new ReactiveObject<bool>();
                 GridSize = new ReactiveObject<int>();

--- a/src/Ryujinx.UI.Common/Configuration/ConfigurationState.cs
+++ b/src/Ryujinx.UI.Common/Configuration/ConfigurationState.cs
@@ -124,6 +124,7 @@ namespace Ryujinx.UI.Common.Configuration
                 ApplicationSort = UI.ApplicationSort,
                 IsAscendingOrder = UI.IsAscendingOrder,
                 StartFullscreen = UI.StartFullscreen,
+                StartNoUI = UI.StartNoUI,
                 ShowConsole = UI.ShowConsole,
                 EnableKeyboard = Hid.EnableKeyboard,
                 EnableMouse = Hid.EnableMouse,
@@ -230,6 +231,7 @@ namespace Ryujinx.UI.Common.Configuration
             UI.ApplicationSort.Value = 0;
             UI.IsAscendingOrder.Value = true;
             UI.StartFullscreen.Value = false;
+            UI.StartNoUI.Value = false;
             UI.ShowConsole.Value = true;
             UI.WindowStartup.WindowSizeWidth.Value = 1280;
             UI.WindowStartup.WindowSizeHeight.Value = 760;

--- a/src/Ryujinx/AppHost.cs
+++ b/src/Ryujinx/AppHost.cs
@@ -1049,6 +1049,14 @@ namespace Ryujinx.Ava
                 }
             });
 
+            Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                if (_viewModel.StartGamesWithoutUI)
+                {
+                    _viewModel.ShowMenuAndStatusBar = false;
+                }
+            });
+
             _renderer = Device.Gpu.Renderer is ThreadedRenderer tr ? tr.BaseRenderer : Device.Gpu.Renderer;
 
             _renderer.ScreenCaptured += Renderer_ScreenCaptured;

--- a/src/Ryujinx/Assets/locales.json
+++ b/src/Ryujinx/Assets/locales.json
@@ -550,6 +550,30 @@
       }
     },
     {
+      "ID": "MenuBarOptionsStartGamesWithoutUI",
+      "Translations": {
+        "ar_SA": "",
+        "de_DE": "",
+        "el_GR": "",
+        "en_US": "Start Games with UI Hidden",
+        "es_ES": "",
+        "fr_FR": "",
+        "he_IL": "",
+        "it_IT": "",
+        "ja_JP": "",
+        "ko_KR": "",
+        "no_NO": "",
+        "pl_PL": "",
+        "pt_BR": "",
+        "ru_RU": "",
+        "th_TH": "",
+        "tr_TR": "",
+        "uk_UA": "",
+        "zh_CN": "",
+        "zh_TW": ""
+      }
+    },
+    {
       "ID": "MenuBarOptionsStopEmulation",
       "Translations": {
         "ar_SA": "إيقاف المحاكاة",

--- a/src/Ryujinx/UI/ViewModels/MainWindowViewModel.cs
+++ b/src/Ryujinx/UI/ViewModels/MainWindowViewModel.cs
@@ -853,6 +853,19 @@ namespace Ryujinx.Ava.UI.ViewModels
             }
         }
 
+        public bool StartGamesWithoutUI
+        {
+            get => ConfigurationState.Instance.UI.StartNoUI;
+            set
+            {
+                ConfigurationState.Instance.UI.StartNoUI.Value = value;
+
+                ConfigurationState.Instance.ToFileFormat().SaveConfig(Program.ConfigurationPath);
+
+                OnPropertyChanged();
+            }
+        }
+
         public bool ShowConsole
         {
             get => ConfigurationState.Instance.UI.ShowConsole;
@@ -1588,6 +1601,11 @@ namespace Ryujinx.Ava.UI.ViewModels
         public void ToggleStartGamesInFullscreen()
         {
             StartGamesInFullscreen = !StartGamesInFullscreen;
+        }
+
+        public void ToggleStartGamesWithoutUI()
+        {
+            StartGamesWithoutUI = !StartGamesWithoutUI;
         }
 
         public void ToggleShowConsole()

--- a/src/Ryujinx/UI/Views/Main/MainMenuBarView.axaml
+++ b/src/Ryujinx/UI/Views/Main/MainMenuBarView.axaml
@@ -121,6 +121,29 @@
                 </MenuItem>
                 <MenuItem
                     Padding="0"
+                    Command="{Binding ToggleStartGamesWithoutUI}"
+                    Header="{ext:Locale MenuBarOptionsStartGamesWithoutUI}">
+                    <MenuItem.Icon>
+                        <CheckBox
+                            MinWidth="{DynamicResource CheckBoxSize}"
+                            MinHeight="{DynamicResource CheckBoxSize}"
+                            IsChecked="{Binding StartGamesWithoutUI, Mode=TwoWay}"
+                            Padding="0" />
+                    </MenuItem.Icon>
+                    <MenuItem.Styles>
+                        <Style Selector="Viewbox#PART_IconPresenter">
+                            <Setter Property="MaxHeight" Value="36" />
+                            <Setter Property="MinHeight" Value="36" />
+                            <Setter Property="MaxWidth" Value="36" />
+                            <Setter Property="MinWidth" Value="36" />
+                        </Style>
+                        <Style Selector="ContentPresenter#PART_HeaderPresenter">
+                            <Setter Property="Padding" Value="-10,0,0,0" />
+                        </Style>
+                    </MenuItem.Styles>
+                </MenuItem>
+                <MenuItem
+                    Padding="0"
                     IsVisible="{Binding ShowConsoleVisible}"
                     Command="{Binding ToggleShowConsole}"
                     Header="{ext:Locale MenuBarOptionsShowConsole}">


### PR DESCRIPTION
Similar in function to the "Start Games in Fullscreen" toggle.
For users who want to run games in windowed/non-fullscreen mode with menu UI hidden:
- Eliminates the need to always click "Hide UI" when launching games
- More seamless experience when using apps like Lossless Scaling