### PR TITLE
Only delay shader translation on Metal

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/ParallelDiskCacheLoader.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/ParallelDiskCacheLoader.cs
@@ -367,9 +367,8 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         {
             try
             {
-                if (_context.DirtyHacks.IsEnabled(DirtyHack.ShaderTranslationDelay))
-                    if (_context.Capabilities.Api == TargetApi.Metal)
-                        Thread.Sleep(_context.DirtyHacks[DirtyHack.ShaderTranslationDelay]);
+                if (_context.Capabilities.Api == TargetApi.Metal && _context.DirtyHacks.IsEnabled(DirtyHack.ShaderTranslationDelay))
+                    Thread.Sleep(_context.DirtyHacks[DirtyHack.ShaderTranslationDelay]);
                 
                 AsyncProgramTranslation asyncTranslation = new(guestShaders, specState, programIndex, isCompute);
                 _asyncTranslationQueue.Add(asyncTranslation, _cancellationToken);

--- a/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/ParallelDiskCacheLoader.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/ParallelDiskCacheLoader.cs
@@ -368,7 +368,8 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
             try
             {
                 if (_context.DirtyHacks.IsEnabled(DirtyHack.ShaderTranslationDelay))
-                    Thread.Sleep(_context.DirtyHacks[DirtyHack.ShaderTranslationDelay]);
+                    if (_context.Capabilities.Api == TargetApi.Metal)
+                        Thread.Sleep(_context.DirtyHacks[DirtyHack.ShaderTranslationDelay]);
                 
                 AsyncProgramTranslation asyncTranslation = new(guestShaders, specState, programIndex, isCompute);
                 _asyncTranslationQueue.Add(asyncTranslation, _cancellationToken);


### PR DESCRIPTION
This way the arbitrary shader translation delay hack will no longer affect shader loading, when using the Vulkan backend