### PR TITLE
Include Hack for XC2 JP Edition

### DIFF
--- a/src/Ryujinx.HLE/HOS/Services/Fs/FileSystemProxy/IStorage.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Fs/FileSystemProxy/IStorage.cs
@@ -15,9 +15,10 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
         {
             _baseStorage = SharedRef<LibHac.FsSrv.Sf.IStorage>.CreateMove(ref baseStorage);
         }
-
+        
         private const string Xc2JpTitleId = "0100f3400332c000";
         private const string Xc2GlobalTitleId = "0100e95004038000";
+        private static bool IsXc2 => TitleIDs.CurrentApplication.Value.OrDefault() is Xc2GlobalTitleId or Xc2JpTitleId;
 
         [CommandCmif(0)]
         // Read(u64 offset, u64 length) -> buffer<u8, 0x46, 0> buffer
@@ -40,7 +41,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
                 using var region = context.Memory.GetWritableRegion(bufferAddress, (int)bufferLen, true);
                 Result result = _baseStorage.Get.Read((long)offset, new OutBuffer(region.Memory.Span), (long)size);
                 
-                if (context.Device.DirtyHacks.IsEnabled(DirtyHack.Xc2MenuSoftlockFix) && (TitleIDs.CurrentApplication.Value == Xc2JpTitleId || TitleIDs.CurrentApplication.Value == Xc2GlobalTitleId))
+                if (context.Device.DirtyHacks.IsEnabled(DirtyHack.Xc2MenuSoftlockFix) && IsXc2)
                 {
                     // Add a load-bearing sleep to avoid XC2 softlock
                     // https://web.archive.org/web/20240728045136/https://github.com/Ryujinx/Ryujinx/issues/2357

--- a/src/Ryujinx.HLE/HOS/Services/Fs/FileSystemProxy/IStorage.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Fs/FileSystemProxy/IStorage.cs
@@ -16,7 +16,8 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
             _baseStorage = SharedRef<LibHac.FsSrv.Sf.IStorage>.CreateMove(ref baseStorage);
         }
 
-        private const string Xc2TitleId = "0100e95004038000";
+        private const string Xc2JpTitleId = "0100f3400332c000";
+        private const string Xc2GlobalTitleId = "0100e95004038000";
 
         [CommandCmif(0)]
         // Read(u64 offset, u64 length) -> buffer<u8, 0x46, 0> buffer
@@ -39,7 +40,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
                 using var region = context.Memory.GetWritableRegion(bufferAddress, (int)bufferLen, true);
                 Result result = _baseStorage.Get.Read((long)offset, new OutBuffer(region.Memory.Span), (long)size);
                 
-                if (context.Device.DirtyHacks.IsEnabled(DirtyHack.Xc2MenuSoftlockFix) && TitleIDs.CurrentApplication.Value == Xc2TitleId)
+                if (context.Device.DirtyHacks.IsEnabled(DirtyHack.Xc2MenuSoftlockFix) && (TitleIDs.CurrentApplication.Value == Xc2JpTitleId || TitleIDs.CurrentApplication.Value == Xc2GlobalTitleId))
                 {
                     // Add a load-bearing sleep to avoid XC2 softlock
                     // https://web.archive.org/web/20240728045136/https://github.com/Ryujinx/Ryujinx/issues/2357


### PR DESCRIPTION
XC2 has 2 editions, one JP and one global. I own the JP version and suffered from the soft-lock, meanwhile the current hack only works for global edition, so PR is simply include JP edition from the hack.