### PR TITLE
reworked workflows

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -108,6 +108,7 @@ jobs:
           sed -r --in-place 's/\%\%RYUJINX_TARGET_RELEASE_CHANNEL_REPO\%\%/${{ env.RYUJINX_TARGET_RELEASE_CHANNEL_REPO }}/g;' src/Ryujinx.Common/ReleaseInformation.cs
           sed -r --in-place 's/\%\%RYUJINX_TARGET_RELEASE_CHANNEL_SOURCE_REPO\%\%/${{ env.RYUJINX_TARGET_RELEASE_CHANNEL_SOURCE_REPO }}/g;' src/Ryujinx.Common/ReleaseInformation.cs
           sed -r --in-place 's/\%\%RYUJINX_CONFIG_FILE_NAME\%\%/Config\.json/g;' src/Ryujinx.Common/ReleaseInformation.cs
+          sed -r --in-place '/^Name=Ryujinx$/s/Name=Ryujinx/Name=Ryujinx-Canary/' distribution/linux/Ryujinx.desktop          
         shell: bash
 
       - name: Create output dir
@@ -115,71 +116,69 @@ jobs:
 
       - name: Publish
         run: |
-          dotnet publish -c Release -r "${{ matrix.platform.name }}" -o ./publish_ava/publish -p:Version="${{ steps.version_info.outputs.build_version }}" -p:SourceRevisionId="${{ steps.version_info.outputs.git_short_hash }}" -p:DebugType=embedded src/Ryujinx --self-contained
+          dotnet publish -c Release -r "${{ matrix.platform.name }}" -o ./publish -p:Version="${{ steps.version_info.outputs.build_version }}" -p:SourceRevisionId="${{ steps.version_info.outputs.git_short_hash }}" -p:DebugType=embedded src/Ryujinx --self-contained
 
       - name: Packing Windows builds
         if: matrix.platform.os == 'windows-latest'
         run: |
-          pushd publish_ava
+          pushd publish
           rm publish/libarmeilleure-jitsupport.dylib
-          7z a ../release_output/ryujinx-canary-${{ steps.version_info.outputs.build_version }}-${{ matrix.platform.zip_os_name }}.zip publish
+          7z a ../release_output/ryujinx-canary-${{ steps.version_info.outputs.build_version }}-${{ matrix.platform.zip_os_name }}.zip ../publish
           popd
         shell: bash
 
       - name: Packing Linux builds
         if: matrix.platform.os == 'ubuntu-latest'
         run: |
-          pushd publish_ava
+          pushd publish
           rm publish/libarmeilleure-jitsupport.dylib
           chmod +x publish/Ryujinx.sh publish/Ryujinx
-          tar -czvf ../release_output/ryujinx-canary-${{ steps.version_info.outputs.build_version }}-${{ matrix.platform.zip_os_name }}.tar.gz publish
+          tar -czvf ../release_output/ryujinx-canary-${{ steps.version_info.outputs.build_version }}-${{ matrix.platform.zip_os_name }}.tar.gz ../publish
           popd
         shell: bash
       
-      #- name: Build AppImage (Linux)
-      #  if: matrix.platform.os == 'ubuntu-latest'
-      #  run: |
-      #    BUILD_VERSION="${{ steps.version_info.outputs.build_version }}"
-      #    PLATFORM_NAME="${{ matrix.platform.name }}"
+      - name: Build AppImage (Linux)
+        if: matrix.platform.os == 'ubuntu-latest'
+        run: |
+          BUILD_VERSION="${{ steps.version_info.outputs.build_version }}"
+          PLATFORM_NAME="${{ matrix.platform.name }}"
 
-      #    sudo apt install -y zsync desktop-file-utils appstream
+          sudo apt install -y zsync desktop-file-utils appstream
 
-      #    mkdir -p tools
-      #    export PATH="$PATH:$(readlink -f tools)"
+          mkdir -p tools
+          export PATH="$PATH:$(readlink -f tools)"
 
           # Setup appimagetool
-      #    wget -q -O tools/appimagetool "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage"
-      #    chmod +x tools/appimagetool
-      #    chmod +x distribution/linux/appimage/build-appimage.sh
+          wget -q -O tools/appimagetool "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage"
+          chmod +x tools/appimagetool
+          chmod +x distribution/linux/appimage/build-appimage.sh
 
           # Explicitly set $ARCH for appimagetool ($ARCH_NAME is for the file name)
-      #    if [ "$PLATFORM_NAME" = "linux-x64" ]; then
-      #      ARCH_NAME=x64
-      #      export ARCH=x86_64
-      #    elif [ "$PLATFORM_NAME" = "linux-arm64" ]; then
-      #      ARCH_NAME=arm64
-      #      export ARCH=aarch64
-      #    else
-      #      echo "Unexpected PLATFORM_NAME "$PLATFORM_NAME""
-      #      exit 1
-      #    fi
+          if [ "$PLATFORM_NAME" = "linux-x64" ]; then
+            ARCH_NAME=x64
+            export ARCH=x86_64
+          elif [ "$PLATFORM_NAME" = "linux-arm64" ]; then
+            ARCH_NAME=arm64
+            export ARCH=aarch64
+          else
+            echo "Unexpected PLATFORM_NAME "$PLATFORM_NAME""
+            exit 1
+          fi
 
-      #    export UFLAG="gh-releases-zsync|${{ github.repository_owner }}|${{ github.event.repository.name }}|latest|*-$ARCH_NAME.AppImage.zsync"
-      #    BUILDDIR=publish_ava OUTDIR=publish_ava_appimage distribution/linux/appimage/build-appimage.sh
+          export UFLAG="gh-releases-zsync|${{ github.repository_owner }}|${{ github.event.repository.name }}|latest|*-$ARCH_NAME.AppImage.zsync"
+          BUILDDIR=publish OUTDIR=publish_appimage distribution/linux/appimage/build-appimage.sh
 
-          # Add to release output
-      #    pushd publish_ava_appimage
-      #    mv Ryujinx.AppImage ../release_output/ryujinx-$BUILD_VERSION-$ARCH_NAME.AppImage
-      #    mv Ryujinx.AppImage.zsync ../release_output/ryujinx-$BUILD_VERSION-$ARCH_NAME.AppImage.zsync
-      #    popd
-      #  shell: bash
+          pushd publish_appimage
+          mv Ryujinx.AppImage ../release_output/ryujinx-$BUILD_VERSION-$ARCH_NAME.AppImage
+          mv Ryujinx.AppImage.zsync ../release_output/ryujinx-$BUILD_VERSION-$ARCH_NAME.AppImage.zsync
+          popd          
+        shell: bash 
 
       - name: Pushing new release
         uses: ncipollo/release-action@v1
         with:
           name: ${{ steps.version_info.outputs.build_version }}
-          artifacts: "release_output/*.tar.gz,release_output/*.zip"
-          #artifacts: "release_output/*.tar.gz,release_output/*.zip,release_output/*AppImage*"
+          artifacts: "release_output/*.tar.gz,release_output/*.zip,release_output/*AppImage*"
           tag: ${{ steps.version_info.outputs.build_version }}
           body: |
             # Canary builds:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,6 +121,15 @@ jobs:
           7z a ../release_output/ryujinx-${{ steps.version_info.outputs.build_version }}-${{ matrix.platform.zip_os_name }}.zip ../publish
           popd
         shell: bash
+
+      - name: Packing Linux builds
+        if: matrix.platform.os == 'ubuntu-latest'
+        run: |
+          pushd publish
+          chmod +x Ryujinx.sh Ryujinx
+          tar -czvf ../release_output/ryujinx-${{ steps.version_info.outputs.build_version }}-${{ matrix.platform.zip_os_name }}.tar.gz ../publish
+          popd
+        shell: bash
       
       - name: Build AppImage (Linux)
         if: matrix.platform.os == 'ubuntu-latest'
@@ -156,15 +165,6 @@ jobs:
           pushd publish_appimage
           mv Ryujinx.AppImage ../release_output/ryujinx-$BUILD_VERSION-$ARCH_NAME.AppImage
           mv Ryujinx.AppImage.zsync ../release_output/ryujinx-$BUILD_VERSION-$ARCH_NAME.AppImage.zsync
-          popd
-        shell: bash        
-
-      - name: Packing Linux builds
-        if: matrix.platform.os == 'ubuntu-latest'
-        run: |
-          pushd publish
-          chmod +x Ryujinx.sh Ryujinx
-          tar -czvf ../release_output/ryujinx-${{ steps.version_info.outputs.build_version }}-${{ matrix.platform.zip_os_name }}.tar.gz ../publish
           popd
         shell: bash
 

--- a/distribution/linux/appimage/build-appimage.sh
+++ b/distribution/linux/appimage/build-appimage.sh
@@ -6,7 +6,7 @@ cd "$ROOTDIR"
 
 BUILDDIR=${BUILDDIR:-publish}
 OUTDIR=${OUTDIR:-publish_appimage}
-UFLAG=${UFLAG:-"gh-releases-zsync|GreemDev|ryujinx|latest|*-x64.AppImage.zsync"}
+UFLAG=${UFLAG:-"gh-releases-zsync|Ryubing|ryujinx|latest|*-x64.AppImage.zsync"}
 
 rm -rf AppDir
 mkdir -p AppDir/usr/bin


### PR DESCRIPTION
this makes `canary.yml` follow the same order of steps as `release.yml`, adding appimages to the canary versions and i fixed some bugs with the `build-appimage.sh` mainly fixing linking to the old repo