### PR TITLE
Add compat of Xenoblade 2 JP edition same as global edition

### DIFF
--- a/docs/compatibility.csv
+++ b/docs/compatibility.csv
@@ -3421,3 +3421,4 @@
 0100936018EB4000,"牧場物語 Welcome！ワンダフルライフ",crash,ingame,2023-04-25 19:43:52
 0100F4401940A000,"超探偵事件簿 レインコード  (Master Detective Archives: Rain Code)",crash,ingame,2024-02-12 20:58:31
 010064801A01C000,"超次元ゲイム ネプテューヌ GameMaker R:Evolution",crash,nothing,2023-10-30 22:37:40
+0100F3400332C000,"ゼノブレイド2",deadlock;amd-vendor-bug,ingame,2024-03-28 14:31:41


### PR DESCRIPTION
Again XC2 JP Edition is somehow missed (due to 2 title IDs for each of worldwide and JP edition), therefore this is just to copy the status of global edition to JP edition.