### PR TITLE
Add/fix service reported info

### DIFF
--- a/src/Ryujinx.HLE/HOS/Services/Settings/ISystemSettingsServer.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Settings/ISystemSettingsServer.cs
@@ -244,6 +244,15 @@ namespace Ryujinx.HLE.HOS.Services.Settings
             return ResultCode.Success;
         }
 
+        [CommandCmif(68)]
+        // GetSerialNumber() -> buffer<nn::settings::system::SerialNumber, 0x16>
+        public ResultCode GetSerialNumber(ServiceCtx context)
+        {
+            context.ResponseData.Write(Encoding.ASCII.GetBytes("RYU00000000000"));
+
+            return ResultCode.Success;
+        }
+
         [CommandCmif(77)]
         // GetDeviceNickName() -> buffer<nn::settings::system::DeviceNickName, 0x16>
         public ResultCode GetDeviceNickName(ServiceCtx context)

--- a/src/Ryujinx.HLE/HOS/Services/Spl/IGeneralInterface.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Spl/IGeneralInterface.cs
@@ -51,6 +51,9 @@ namespace Ryujinx.HLE.HOS.Services.Spl
 
             context.ResponseData.Write(configValue);
 
+            if (result == SmcResult.Success)
+                return ResultCode.Success;
+
             return (ResultCode)((int)result << 9) | ResultCode.ModuleId;
         }
 


### PR DESCRIPTION
fixes the GetConfig service call, which now returns success correctly
adds support for getting the device serial number (which is fake and reports as "RYU00000000000")