### PR TITLE
Log .NET runtime version

### DIFF
--- a/src/Ryujinx/Program.cs
+++ b/src/Ryujinx/Program.cs
@@ -230,6 +230,7 @@ namespace Ryujinx.Ava
         internal static void PrintSystemInfo()
         {
             Logger.Notice.Print(LogClass.Application, $"{RyujinxApp.FullAppName} Version: {Version}");
+            Logger.Notice.Print(LogClass.Application, $"Runtime: {RuntimeInformation.FrameworkDescription}");
             SystemInfo.Gather().Print();
 
             var enabledLogLevels = Logger.GetEnabledLevels().ToArray();

--- a/src/Ryujinx/Program.cs
+++ b/src/Ryujinx/Program.cs
@@ -230,7 +230,7 @@ namespace Ryujinx.Ava
         internal static void PrintSystemInfo()
         {
             Logger.Notice.Print(LogClass.Application, $"{RyujinxApp.FullAppName} Version: {Version}");
-            Logger.Notice.Print(LogClass.Application, $"Runtime: {RuntimeInformation.FrameworkDescription}");
+            Logger.Notice.Print(LogClass.Application, $".NET Runtime: {RuntimeInformation.FrameworkDescription}");
             SystemInfo.Gather().Print();
 
             var enabledLogLevels = Logger.GetEnabledLevels().ToArray();


### PR DESCRIPTION
I was looking into a crash, and found out it was an issue that was fixed in .NET 9.0.1. Since Ryujinx embeds the runtime into the executable, it not obvious which runtime a build uses. This logs the .NET runtime version immediately after the build version.