### PR TITLE
Add TitleID sort method

### DIFF
--- a/src/Ryujinx/UI/ViewModels/MainWindowViewModel.cs
+++ b/src/Ryujinx/UI/ViewModels/MainWindowViewModel.cs
@@ -624,6 +624,7 @@ namespace Ryujinx.Ava.UI.ViewModels
                     ApplicationSort.FileSize => LocaleManager.Instance[LocaleKeys.GameListHeaderFileSize],
                     ApplicationSort.Path => LocaleManager.Instance[LocaleKeys.GameListHeaderPath],
                     ApplicationSort.Favorite => LocaleManager.Instance[LocaleKeys.CommonFavorite],
+                    ApplicationSort.TitleId => LocaleManager.Instance[LocaleKeys.DlcManagerTableHeadingTitleIdLabel],
                     _ => string.Empty,
                 };
             }
@@ -694,6 +695,7 @@ namespace Ryujinx.Ava.UI.ViewModels
         public IHostUIHandler UiHandler { get; internal set; }
         public bool IsSortedByFavorite => SortMode == ApplicationSort.Favorite;
         public bool IsSortedByTitle => SortMode == ApplicationSort.Title;
+        public bool IsSortedByTitleId => SortMode == ApplicationSort.TitleId;
         public bool IsSortedByDeveloper => SortMode == ApplicationSort.Developer;
         public bool IsSortedByLastPlayed => SortMode == ApplicationSort.LastPlayed;
         public bool IsSortedByTimePlayed => SortMode == ApplicationSort.TotalTimePlayed;
@@ -726,6 +728,7 @@ namespace Ryujinx.Ava.UI.ViewModels
                 ApplicationSort.FileSize        => CreateComparer(IsAscending, app => app.FileSize),
                 ApplicationSort.Path            => CreateComparer(IsAscending, app => app.Path),
                 ApplicationSort.Favorite        => CreateComparer(IsAscending, app => new AppListFavoriteComparable(app)),
+                ApplicationSort.TitleId         => CreateComparer(IsAscending, app => app.Id),
                 _ => null,
 #pragma warning restore IDE0055
             };

--- a/src/Ryujinx/UI/Views/Main/MainViewControls.axaml
+++ b/src/Ryujinx/UI/Views/Main/MainViewControls.axaml
@@ -107,6 +107,12 @@
                                 Tag="Title" />
                             <RadioButton
                                 Checked="Sort_Checked"
+                                Content="{ext:Locale DlcManagerTableHeadingTitleIdLabel}"
+                                GroupName="Sort"
+                                IsChecked="{Binding IsSortedByTitleId, Mode=OneTime}"
+                                Tag="TitleId" />
+                            <RadioButton
+                                Checked="Sort_Checked"
                                 Content="{ext:Locale GameListHeaderDeveloper}"
                                 GroupName="Sort"
                                 IsChecked="{Binding IsSortedByDeveloper, Mode=OneTime}"


### PR DESCRIPTION
Adds an additional application list sorting method for the TitleID. A bit of a niche choice for sorting but I think the TID is a relevant enough piece of metadata that it should be there. (And I personally would be using it)

- Using existing TitleId constant in ApplicationSort, implying this was meant to be in the sorting options at some point?
- Reuses the "DlcManagerTableHeadingTitleIdLabel" locale for fulfilling the need already, might be better to make a unique one for this in the long run but this codebase is new to me so I wanted to make the changes as unobtrusive as possible
- Using app.Id for the comparer seems to work fine, not sure if using something else like IdString would be better?