### PR TITLE
Add more games to metal game list

### DIFF
--- a/src/Ryujinx.Common/TitleIDs.cs
+++ b/src/Ryujinx.Common/TitleIDs.cs
@@ -28,22 +28,29 @@ namespace Ryujinx.Common
         
         public static readonly string[] GreatMetalTitles =
         [
-            "01006f8002326000", // Animal Crossings: New Horizons
-            "010076f0049a2000", // Bayonetta
-            "01009bf0072d4000", // Captain Toad: Treasure Tracker
             "0100a5c00d162000", // Cuphead
             "010023800d64a000", // Deltarune
-            "01003a30012c0000", // LEGO City Undercover
             "010028600EBDA000", // Mario 3D World
             "0100152000022000", // Mario Kart 8 Deluxe
-            "01005CA01580E000", // Persona 5
             "0100187003A36000", // Pokémon: Let's Go, Eevee!
             "010003f003a34000", // Pokémon: Let's Go, Pikachu!
             "01008C0016544000", // Sea of Stars
             "01006A800016E000", // Smash Ultimate
-            "010015100b514000", // Super Mario Bros. Wonder
-            "0100000000010000", // Super Mario Odyessy
             "01006bb00c6f0000", // The Legend of Zelda: Link's Awakening
+
+            //These ones have small issues, but those happen on Vulkan as well:
+            "01006f8002326000", // Animal Crossings: New Horizons
+            "01009bf0072d4000", // Captain Toad: Treasure Tracker
+            "01005CA01580E000", // Persona 5 Royale
+            "0100000000010000", // Super Mario Odyssey
+
+            //More testing needed:
+            "010076f0049a2000", // Bayonetta
+            "01009510001ca000", // Fast RMX
+            "01003a30012c0000", // LEGO City Undercover
+            "0100704000B3A000", // Snipperclips
+            "01008e20047dc000", // Snipperclips Plus
+            "010015100b514000", // Super Mario Bros. Wonder
         ];
         
         public static string GetDiscordGameAsset(string titleId) 

--- a/src/Ryujinx.Common/TitleIDs.cs
+++ b/src/Ryujinx.Common/TitleIDs.cs
@@ -29,17 +29,21 @@ namespace Ryujinx.Common
         public static readonly string[] GreatMetalTitles =
         [
             "01006f8002326000", // Animal Crossings: New Horizons
+            "010076f0049a2000", // Bayonetta
             "01009bf0072d4000", // Captain Toad: Treasure Tracker
             "0100a5c00d162000", // Cuphead
             "010023800d64a000", // Deltarune
+            "01003a30012c0000", // LEGO City Undercover
             "010028600EBDA000", // Mario 3D World
             "0100152000022000", // Mario Kart 8 Deluxe
             "01005CA01580E000", // Persona 5
-            "0100187003A36000", // Pokémon: Let's Go, Evoli!
+            "0100187003A36000", // Pokémon: Let's Go, Eevee!
             "010003f003a34000", // Pokémon: Let's Go, Pikachu!
             "01008C0016544000", // Sea of Stars
             "01006A800016E000", // Smash Ultimate
+            "010015100b514000", // Super Mario Bros. Wonder
             "0100000000010000", // Super Mario Odyessy
+            "01006bb00c6f0000", // The Legend of Zelda: Link's Awakening
         ];
         
         public static string GetDiscordGameAsset(string titleId) 

--- a/src/Ryujinx.Common/TitleIDs.cs
+++ b/src/Ryujinx.Common/TitleIDs.cs
@@ -28,8 +28,10 @@ namespace Ryujinx.Common
         
         public static readonly string[] GreatMetalTitles =
         [
+            "010076f0049a2000", // Bayonetta
             "0100a5c00d162000", // Cuphead
             "010023800d64a000", // Deltarune
+            "01003a30012c0000", // LEGO City Undercover
             "010028600EBDA000", // Mario 3D World
             "0100152000022000", // Mario Kart 8 Deluxe
             "0100187003A36000", // Pokémon: Let's Go, Eevee!
@@ -41,15 +43,11 @@ namespace Ryujinx.Common
             //These ones have small issues, but those happen on Vulkan as well:
             "01006f8002326000", // Animal Crossings: New Horizons
             "01009bf0072d4000", // Captain Toad: Treasure Tracker
+            "01009510001ca000", // Fast RMX
             "01005CA01580E000", // Persona 5 Royale
             "0100000000010000", // Super Mario Odyssey
 
-            //More testing needed:
-            "010076f0049a2000", // Bayonetta
-            "01009510001ca000", // Fast RMX
-            "01003a30012c0000", // LEGO City Undercover
-            "0100704000B3A000", // Snipperclips
-            "01008e20047dc000", // Snipperclips Plus
+            //Isaac claims it has a issue in level 2, but I am not able to replicate it on my M3. More testing would be appreciated:
             "010015100b514000", // Super Mario Bros. Wonder
         ];
         


### PR DESCRIPTION
Link's awakening I have played through most of the game with 0 issues.

In LEGO City undercover I have played multiple missions and explored the map, I was unable to spot any issue. Except shadows flickering sometimes, but that seems to happen on Vulkan and the PC version as well and is propably normal.

Bayonetta seems to work flawless so far.

In Fast RMX, some tracks have flickering issues, like the second track of the first cup. This happens on Vulkan as well. 

-

Mario Bros. Wonder has following issues:

Overall issues:
- Sometimes there is short white flickering/artifacts, but they happen on Vulkan as well.

Metal specific issue:
- In 2 underwater levels, a specific location causes a FPS drop not present on Vulkan. But this is very minor and on all current M chips you get on average better FPS with Metal (On my M3, there are occasional drops that are worse with Vulkan), reducing stutter quite noticeably, which is why I think it should get added to auto regardless.

- Isaac mentioned there is a issue in level 2, where the flowers singing desync somehow. However, I was after lot of testing unable to replicate this issue at all. More testing could be useful.

Fix: Fixed 2 typos in the comments