### PR TITLE
Fix LED turning on in input settings, despite TurnOffLed being set to true

### DIFF
--- a/src/Ryujinx/UI/Views/Input/ControllerInputView.axaml.cs
+++ b/src/Ryujinx/UI/Views/Input/ControllerInputView.axaml.cs
@@ -251,7 +251,7 @@ namespace Ryujinx.Ava.UI.Views.Input
             if (!args.NewColor.HasValue) return;
             if (DataContext is not ControllerInputViewModel cVm) return;
             if (!cVm.Config.EnableLedChanging) return;
-
+            
             cVm.ParentModel.SelectedGamepad.SetLed(args.NewColor.Value.ToUInt32());
         }
 
@@ -259,8 +259,14 @@ namespace Ryujinx.Ava.UI.Views.Input
         {
             if (DataContext is not ControllerInputViewModel cVm) return;
             if (!cVm.Config.EnableLedChanging) return;
-
-            cVm.ParentModel.SelectedGamepad.SetLed(cVm.Config.LedColor.ToUInt32());
+            if (cVm.Config.TurnOffLed)
+            {
+                cVm.ParentModel.SelectedGamepad.ClearLed();
+            }
+            else
+            {
+                cVm.ParentModel.SelectedGamepad.SetLed(cVm.Config.LedColor.ToUInt32());
+            }
         }
     }
 }

--- a/src/Ryujinx/UI/Views/Input/ControllerInputView.axaml.cs
+++ b/src/Ryujinx/UI/Views/Input/ControllerInputView.axaml.cs
@@ -262,7 +262,6 @@ namespace Ryujinx.Ava.UI.Views.Input
             if (DataContext is not ControllerInputViewModel cVm) return;
             if (!cVm.Config.EnableLedChanging) return;
             if (cVm.Config.TurnOffLed) return;
-            
             cVm.ParentModel.SelectedGamepad.SetLed(cVm.Config.LedColor.ToUInt32());
         }
     }

--- a/src/Ryujinx/UI/Views/Input/ControllerInputView.axaml.cs
+++ b/src/Ryujinx/UI/Views/Input/ControllerInputView.axaml.cs
@@ -253,6 +253,7 @@ namespace Ryujinx.Ava.UI.Views.Input
             if (DataContext is not ControllerInputViewModel cVm) return;
             if (!cVm.Config.EnableLedChanging) return;
             if (cVm.Config.TurnOffLed) return;
+            
             cVm.ParentModel.SelectedGamepad.SetLed(args.NewColor.Value.ToUInt32());
         }
 
@@ -261,6 +262,7 @@ namespace Ryujinx.Ava.UI.Views.Input
             if (DataContext is not ControllerInputViewModel cVm) return;
             if (!cVm.Config.EnableLedChanging) return;
             if (cVm.Config.TurnOffLed) return;
+            
             cVm.ParentModel.SelectedGamepad.SetLed(cVm.Config.LedColor.ToUInt32());
         }
     }

--- a/src/Ryujinx/UI/Views/Input/ControllerInputView.axaml.cs
+++ b/src/Ryujinx/UI/Views/Input/ControllerInputView.axaml.cs
@@ -262,6 +262,7 @@ namespace Ryujinx.Ava.UI.Views.Input
             if (DataContext is not ControllerInputViewModel cVm) return;
             if (!cVm.Config.EnableLedChanging) return;
             if (cVm.Config.TurnOffLed) return;
+            
             cVm.ParentModel.SelectedGamepad.SetLed(cVm.Config.LedColor.ToUInt32());
         }
     }

--- a/src/Ryujinx/UI/Views/Input/ControllerInputView.axaml.cs
+++ b/src/Ryujinx/UI/Views/Input/ControllerInputView.axaml.cs
@@ -251,7 +251,7 @@ namespace Ryujinx.Ava.UI.Views.Input
             if (!args.NewColor.HasValue) return;
             if (DataContext is not ControllerInputViewModel cVm) return;
             if (!cVm.Config.EnableLedChanging) return;
-            
+            if (cVm.Config.TurnOffLed) return;
             cVm.ParentModel.SelectedGamepad.SetLed(args.NewColor.Value.ToUInt32());
         }
 
@@ -259,14 +259,8 @@ namespace Ryujinx.Ava.UI.Views.Input
         {
             if (DataContext is not ControllerInputViewModel cVm) return;
             if (!cVm.Config.EnableLedChanging) return;
-            if (cVm.Config.TurnOffLed)
-            {
-                cVm.ParentModel.SelectedGamepad.ClearLed();
-            }
-            else
-            {
-                cVm.ParentModel.SelectedGamepad.SetLed(cVm.Config.LedColor.ToUInt32());
-            }
+            if (cVm.Config.TurnOffLed) return;
+            cVm.ParentModel.SelectedGamepad.SetLed(cVm.Config.LedColor.ToUInt32());
         }
     }
 }


### PR DESCRIPTION
The ColorPicker auotmatically sets the LED to the selected Color whenever the Input Settings are opened. Therefore it now checks if the setting is turned off before changing the color. Yes, the "colorpicker_on_value_changed" function does this as well, even if you are not changing the color.