### PR TITLE
Increase NAT discovery timeout to 5000ms

### DIFF
--- a/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/Proxy/P2pProxyServer.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/Proxy/P2pProxyServer.cs
@@ -113,7 +113,7 @@ namespace Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator.LdnRyu.Proxy
         public async Task<ushort> NatPunch()
         {
             NatDiscoverer discoverer = new();
-            CancellationTokenSource cts = new(1000);
+            CancellationTokenSource cts = new(5000);
 
             NatDevice device;
 


### PR DESCRIPTION
1000ms was too fast on some slower networks. It would lead to an early cancellation before device could be found.