### PR TITLE
Add more games to Metal Auto list

### DIFF
--- a/src/Ryujinx.Common/TitleIDs.cs
+++ b/src/Ryujinx.Common/TitleIDs.cs
@@ -52,7 +52,7 @@ namespace Ryujinx.Common
             "010015100b514000", // Super Mario Bros. Wonder
             "0100000000010000", // Super Mario Odyssey
 
-            // Further testing is appreciated, I only tested the beginning:
+            // Further testing is appreciated, I did not test the entire game:
             "01007300020fa000", // Astral Chain
             "010076f0049a2000", // Bayonetta
             "0100cf5010fec000", // Bayonetta Origins: Cereza and the Lost Demon

--- a/src/Ryujinx.Common/TitleIDs.cs
+++ b/src/Ryujinx.Common/TitleIDs.cs
@@ -50,10 +50,13 @@ namespace Ryujinx.Common
             "01009bf0072d4000", // Captain Toad: Treasure Tracker
             "01009510001ca000", // Fast RMX
             "01005CA01580E000", // Persona 5 Royale
+            "010015100b514000", // Super Mario Bros. Wonder
             "0100000000010000", // Super Mario Odyssey
 
-            // Isaac claims it has an issue in level 2, but I am not able to replicate it on my M3. More testing would be appreciated:
-            "010015100b514000", // Super Mario Bros. Wonder
+            // Further testing is appreciated:
+            "01007300020fa000", // ASTRAL CHAIN
+            "0100cf5010fec000", // Bayonetta Origins: Cereza and the Lost Demon
+            "0100f4300bf2c000", // New Pokemon Snap
         ];
         
         public static string GetDiscordGameAsset(string titleId) 

--- a/src/Ryujinx.Common/TitleIDs.cs
+++ b/src/Ryujinx.Common/TitleIDs.cs
@@ -31,7 +31,6 @@ namespace Ryujinx.Common
         public static readonly string[] GreatMetalTitles =
         [
             "01009b500007c000", // ARMS
-            "010076f0049a2000", // Bayonetta
             "0100a5c00d162000", // Cuphead
             "010023800d64a000", // Deltarune
             "01003a30012c0000", // LEGO City Undercover
@@ -53,8 +52,9 @@ namespace Ryujinx.Common
             "010015100b514000", // Super Mario Bros. Wonder
             "0100000000010000", // Super Mario Odyssey
 
-            // Further testing is appreciated:
-            "01007300020fa000", // ASTRAL CHAIN
+            // Further testing is appreciated, I only tested the beginning:
+            "01007300020fa000", // Astral Chain
+            "010076f0049a2000", // Bayonetta
             "0100cf5010fec000", // Bayonetta Origins: Cereza and the Lost Demon
             "0100f4300bf2c000", // New Pokemon Snap
         ];

--- a/src/Ryujinx.Common/TitleIDs.cs
+++ b/src/Ryujinx.Common/TitleIDs.cs
@@ -30,10 +30,12 @@ namespace Ryujinx.Common
         
         public static readonly string[] GreatMetalTitles =
         [
+            "01009b500007c000", // ARMS
             "010076f0049a2000", // Bayonetta
             "0100a5c00d162000", // Cuphead
             "010023800d64a000", // Deltarune
             "01003a30012c0000", // LEGO City Undercover
+            "010048701995e000", // Luigi's Manion 2 HD
             "010028600EBDA000", // Mario 3D World
             "0100152000022000", // Mario Kart 8 Deluxe
             "010075a016a3a000", // Persona 4 Arena Ultimax
@@ -50,7 +52,7 @@ namespace Ryujinx.Common
             "01005CA01580E000", // Persona 5 Royale
             "0100000000010000", // Super Mario Odyssey
 
-            //Isaac claims it has a issue in level 2, but I am not able to replicate it on my M3. More testing would be appreciated:
+            // Isaac claims it has an issue in level 2, but I am not able to replicate it on my M3. More testing would be appreciated:
             "010015100b514000", // Super Mario Bros. Wonder
         ];
         


### PR DESCRIPTION
ARMS: Tested every character and every Map, played a cup as well. It works flawless in my testing. (If it freezes, that is caused by the Hypervisor, not Metal. You need to disable the Hypervisor for this game)

Luigi's Mansion 2 HD: I tested every world a bit and had no issue. Isaac said he specifically worked on it as well

Following games were flawless in my testing, but I only tested earlier parts of the game so far, a late game part might have an issue, therefore I will further test these in the future:

- Astral Chain
- Bayonetta Origins
- New Pokemon Snap