### PR TITLE
Work around the current Metal renderer's broken resolution scaling

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/GraphicsConfig.cs
+++ b/src/Ryujinx.Graphics.Gpu/GraphicsConfig.cs
@@ -1,3 +1,5 @@
+using Ryujinx.Common.Configuration;
+
 namespace Ryujinx.Graphics.Gpu
 {
 #pragma warning disable CA2211 // Non-constant fields should not be visible
@@ -7,9 +9,20 @@ namespace Ryujinx.Graphics.Gpu
     public static class GraphicsConfig
     {
         /// <summary>
+        /// The graphics backend currently in use.
+        /// </summary>
+        public static GraphicsBackend CurrentBackend;
+
+        private static float _resScale = 1f;
+
+        /// <summary>
         /// Resolution scale.
         /// </summary>
-        public static float ResScale = 1f;
+        public static float ResScale
+        {
+            get => CurrentBackend is GraphicsBackend.Metal ? 1 : _resScale;
+            set => _resScale = value;
+        }
 
         /// <summary>
         /// Max Anisotropy. Values range from 0 - 16. Set to -1 to let the game decide.

--- a/src/Ryujinx/AppHost.cs
+++ b/src/Ryujinx/AppHost.cs
@@ -691,7 +691,6 @@ namespace Ryujinx.Ava
             DiscordIntegrationModule.GuestAppStartedAt = Timestamps.Now;
             
             InitEmulatedSwitch();
-            MainWindow.UpdateGraphicsConfig();
 
             SystemVersion firmwareVersion = ContentManager.GetCurrentFirmwareVersion();
 
@@ -1307,11 +1306,12 @@ namespace Ryujinx.Ava
                             _viewModel.Volume = Device.GetVolume();
                             break;
                         case KeyboardHotkeyState.ResScaleUp:
-                            GraphicsConfig.ResScale = GraphicsConfig.ResScale % MaxResolutionScale + 1;
+                            if (GraphicsConfig.CurrentBackend is not GraphicsBackend.Metal)
+                                GraphicsConfig.ResScale = GraphicsConfig.ResScale % MaxResolutionScale + 1;
                             break;
                         case KeyboardHotkeyState.ResScaleDown:
-                            GraphicsConfig.ResScale =
-                            (MaxResolutionScale + GraphicsConfig.ResScale - 2) % MaxResolutionScale + 1;
+                            if (GraphicsConfig.CurrentBackend is not GraphicsBackend.Metal)
+                                GraphicsConfig.ResScale = (MaxResolutionScale + GraphicsConfig.ResScale - 2) % MaxResolutionScale + 1;
                             break;
                         case KeyboardHotkeyState.VolumeUp:
                             _newVolume = MathF.Round((Device.GetVolume() + VolumeDelta), 2);

--- a/src/Ryujinx/Headless/HeadlessRyujinx.cs
+++ b/src/Ryujinx/Headless/HeadlessRyujinx.cs
@@ -280,6 +280,7 @@ namespace Ryujinx.Headless
             }
 
             // Setup graphics configuration
+            GraphicsConfig.CurrentBackend = option.GraphicsBackend is GraphicsBackend.Auto ? GraphicsBackend.Vulkan : option.GraphicsBackend;
             GraphicsConfig.EnableShaderCache = !option.DisableShaderCache;
             GraphicsConfig.EnableTextureRecompression = option.EnableTextureRecompression;
             GraphicsConfig.ResScale = option.ResScale;
@@ -356,11 +357,15 @@ namespace Ryujinx.Headless
         {
             return options.GraphicsBackend switch
             {
-                GraphicsBackend.Vulkan => new VulkanWindow(_inputManager, options.LoggingGraphicsDebugLevel, options.AspectRatio, options.EnableMouse, options.HideCursorMode, options.IgnoreControllerApplet),
-                GraphicsBackend.Metal => OperatingSystem.IsMacOS() ?
-                    new MetalWindow(_inputManager, options.LoggingGraphicsDebugLevel, options.AspectRatio, options.EnableKeyboard, options.HideCursorMode, options.IgnoreControllerApplet) :
-                    throw new Exception("Attempted to use Metal renderer on non-macOS platform!"),
-                _ => new OpenGLWindow(_inputManager, options.LoggingGraphicsDebugLevel, options.AspectRatio, options.EnableMouse, options.HideCursorMode, options.IgnoreControllerApplet)
+                GraphicsBackend.OpenGl => 
+                    !OperatingSystem.IsMacOS() 
+                        ? new OpenGLWindow(_inputManager, options.LoggingGraphicsDebugLevel, options.AspectRatio, options.EnableMouse, options.HideCursorMode, options.IgnoreControllerApplet)
+                        : throw new InvalidOperationException("Attempted to use OpenGL renderer on macOS platform!"),
+                GraphicsBackend.Metal => 
+                    OperatingSystem.IsMacOS() 
+                        ? new MetalWindow(_inputManager, options.LoggingGraphicsDebugLevel, options.AspectRatio, options.EnableKeyboard, options.HideCursorMode, options.IgnoreControllerApplet) 
+                        : throw new InvalidOperationException("Attempted to use Metal renderer on non-macOS platform!"),
+                _ => new VulkanWindow(_inputManager, options.LoggingGraphicsDebugLevel, options.AspectRatio, options.EnableMouse, options.HideCursorMode, options.IgnoreControllerApplet),
             };
         }
 

--- a/src/Ryujinx/UI/Renderer/RendererHost.cs
+++ b/src/Ryujinx/UI/Renderer/RendererHost.cs
@@ -1,6 +1,7 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Media;
+using Ryujinx.Ava.UI.Windows;
 using Ryujinx.Ava.Utilities.Configuration;
 using Ryujinx.Common;
 using Ryujinx.Common.Configuration;
@@ -43,6 +44,8 @@ namespace Ryujinx.Ava.UI.Renderer
 
         public RendererHost(string titleId)
         {
+            MainWindow.UpdateGraphicsConfig(titleId);
+            
             switch (TitleIDs.SelectGraphicsBackend(titleId, ConfigurationState.Instance.Graphics.GraphicsBackend))
             {
                 case GraphicsBackend.OpenGl:

--- a/src/Ryujinx/UI/Windows/MainWindow.axaml.cs
+++ b/src/Ryujinx/UI/Windows/MainWindow.axaml.cs
@@ -20,6 +20,7 @@ using Ryujinx.Ava.Utilities;
 using Ryujinx.Ava.Utilities.AppLibrary;
 using Ryujinx.Ava.Utilities.Configuration;
 using Ryujinx.Common;
+using Ryujinx.Common.Configuration;
 using Ryujinx.Common.Helper;
 using Ryujinx.Common.Logging;
 using Ryujinx.Common.UI;
@@ -541,12 +542,11 @@ namespace Ryujinx.Ava.UI.Windows
             }
         }
 
-        public static void UpdateGraphicsConfig()
+        public static void UpdateGraphicsConfig(string titleId = null)
         {
 #pragma warning disable IDE0055 // Disable formatting
-            GraphicsConfig.ResScale                   = ConfigurationState.Instance.Graphics.ResScale == -1 
-                ? ConfigurationState.Instance.Graphics.ResScaleCustom 
-                : ConfigurationState.Instance.Graphics.ResScale;
+            GraphicsConfig.CurrentBackend                = TitleIDs.SelectGraphicsBackend(titleId, ConfigurationState.Instance.Graphics.GraphicsBackend);
+            GraphicsConfig.ResScale                      = ConfigurationState.Instance.Graphics.GetScalingFactor(titleId);
             GraphicsConfig.MaxAnisotropy              = ConfigurationState.Instance.Graphics.MaxAnisotropy;
             GraphicsConfig.ShadersDumpPath            = ConfigurationState.Instance.Graphics.ShadersDumpPath;
             GraphicsConfig.EnableShaderCache          = ConfigurationState.Instance.Graphics.EnableShaderCache;

--- a/src/Ryujinx/Utilities/Configuration/ConfigurationState.Model.cs
+++ b/src/Ryujinx/Utilities/Configuration/ConfigurationState.Model.cs
@@ -479,6 +479,16 @@ namespace Ryujinx.Ava.Utilities.Configuration
             /// </summary>
             public ReactiveObject<int> ResScale { get; private set; }
 
+            public float GetScalingFactor(string titleId = null)
+            {
+                if (titleId is null) return 1;
+                
+                if (TitleIDs.SelectGraphicsBackend(titleId, GraphicsBackend) is Ryujinx.Common.Configuration.GraphicsBackend.Metal)
+                    return 1;
+                
+                return ResScale == -1 ? ResScaleCustom : ResScale;
+            }
+
             /// <summary>
             /// Custom Resolution Scale. A custom floating point scale applied to applicable render targets. Only active when Resolution Scale is -1.
             /// </summary>


### PR DESCRIPTION
Simply clamps the chosen res scale to 1x if the renderer (after Auto detection) is Metal.