### PR TITLE
UI: Pretty Atmosphère mod names

### DIFF
--- a/src/Ryujinx/UI/Models/ModModel.cs
+++ b/src/Ryujinx/UI/Models/ModModel.cs
@@ -1,5 +1,5 @@
 using Ryujinx.Ava.UI.ViewModels;
-using System.IO;
+using System.Globalization;
 
 namespace Ryujinx.Ava.UI.Models
 {
@@ -20,6 +20,11 @@ namespace Ryujinx.Ava.UI.Models
         public bool InSd { get; }
         public string Path { get; }
         public string Name { get; }
+
+        public string FormattedName => 
+            InSd && ulong.TryParse(Name, NumberStyles.HexNumber, null, out ulong applicationId)
+                ? $"Atmosphère: {System.IO.Path.GetFileNameWithoutExtension(RyujinxApp.MainWindow.ApplicationLibrary.GetNameForApplicationId(applicationId))}"
+                : Name;
 
         public ModModel(string path, string name, bool enabled, bool inSd)
         {

--- a/src/Ryujinx/UI/Windows/ModManagerWindow.axaml
+++ b/src/Ryujinx/UI/Windows/ModManagerWindow.axaml
@@ -81,7 +81,7 @@
                                     MaxLines="2"
                                     TextWrapping="Wrap"
                                     TextTrimming="CharacterEllipsis"
-                                    Text="{Binding Name}" />
+                                    Text="{Binding FormattedName}" />
                                 <StackPanel
                                     Grid.Column="1"
                                     Spacing="10"

--- a/src/Ryujinx/Utilities/AppLibrary/ApplicationLibrary.cs
+++ b/src/Ryujinx/Utilities/AppLibrary/ApplicationLibrary.cs
@@ -128,10 +128,9 @@ namespace Ryujinx.Ava.Utilities.AppLibrary
             DynamicData.Kernel.Optional<ApplicationData> appData = Applications.Lookup(id);
             if (appData.HasValue)
                 return appData.Value.Name;
-
-            Gommon.Optional<DownloadableContentModel> dlcData = DownloadableContents.Keys.FindFirst(x => x.TitleId == id);
-            if (dlcData.HasValue)
-                return dlcData.Value.FileName;
+            
+            if (DownloadableContents.Keys.FindFirst(x => x.TitleId == id).TryGet(out DownloadableContentModel dlcData))
+                return dlcData.FileName;
 
             return id.ToString("X16");
         }

--- a/src/Ryujinx/Utilities/AppLibrary/ApplicationLibrary.cs
+++ b/src/Ryujinx/Utilities/AppLibrary/ApplicationLibrary.cs
@@ -111,6 +111,18 @@ namespace Ryujinx.Ava.Utilities.AppLibrary
             return data;
         }
 
+        /// <summary>
+        ///     Gets a name for an available content file based on the Application ID '<paramref name="id"/>'.
+        ///     <br/><br/>
+        ///     For Applications, this returns the localized name of the app found in the file.
+        ///     For DLCs, this returns the name of the file that contains the DLC, minus the file extension.
+        /// </summary>
+        /// <param name="id">The Application ID to search for.</param>
+        /// <remarks>
+        /// If the provided Application ID does not have a corresponding Application OR DLC file,
+        /// <paramref name="id"/> formatted as hexadecimal is returned.
+        /// </remarks>
+        /// <returns>A formatted Application name, or <paramref name="id"/> as hexadecimal if none is found.</returns>
         public string GetNameForApplicationId(ulong id)
         {
             DynamicData.Kernel.Optional<ApplicationData> appData = Applications.Lookup(id);

--- a/src/Ryujinx/Utilities/AppLibrary/ApplicationLibrary.cs
+++ b/src/Ryujinx/Utilities/AppLibrary/ApplicationLibrary.cs
@@ -111,6 +111,19 @@ namespace Ryujinx.Ava.Utilities.AppLibrary
             return data;
         }
 
+        public string GetNameForApplicationId(ulong id)
+        {
+            DynamicData.Kernel.Optional<ApplicationData> appData = Applications.Lookup(id);
+            if (appData.HasValue)
+                return appData.Value.Name;
+
+            Gommon.Optional<DownloadableContentModel> dlcData = DownloadableContents.Keys.FindFirst(x => x.TitleId == id);
+            if (dlcData.HasValue)
+                return dlcData.Value.FileName;
+
+            return id.ToString("X16");
+        }
+
         /// <exception cref="LibHac.Common.Keys.MissingKeyException">The configured key set is missing a key.</exception>
         /// <exception cref="InvalidDataException">The NCA header could not be decrypted.</exception>
         /// <exception cref="NotSupportedException">The NCA version is not supported.</exception>


### PR DESCRIPTION
Changes the mods from the Atmosphère folder to show a pretty name instead of just the name of the folder they're in, because those names are always just a title ID.

NOTE: The DLC names are from the file names, not retrieved from the content file itself like the main applications.

![](https://i.imgur.com/RrcM42N.png)