### PR TITLE
Applet Prep + System Buffer Sharing

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Engine/Compute/ComputeClass.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/Compute/ComputeClass.cs
@@ -107,7 +107,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Compute
 
             shaderGpuVa += (uint)qmd.ProgramOffset;
             
-            var shaderCache = memoryManager.GetBackingMemory(shaderGpuVa).ShaderCache;
+            ShaderCache shaderCache = memoryManager.GetBackingMemory(shaderGpuVa).ShaderCache;
 
             int localMemorySize = qmd.ShaderLocalMemoryLowSize + qmd.ShaderLocalMemoryHighSize;
 
@@ -158,7 +158,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Compute
             {
                 BufferDescriptor sb = info.SBuffers[index];
 
-                (var physical, ulong sbDescAddress) = _channel.BufferManager.GetComputeUniformBufferAddress(sb.SbCbSlot);
+                (PhysicalMemory physical, ulong sbDescAddress) = _channel.BufferManager.GetComputeUniformBufferAddress(sb.SbCbSlot);
                 sbDescAddress += (ulong)sb.SbCbOffset * 4;
 
                 SbDescriptor sbDescriptor = physical.Read<SbDescriptor>(sbDescAddress);

--- a/src/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
@@ -215,7 +215,10 @@ namespace Ryujinx.Graphics.Gpu.Engine.Dma
             _channel.TextureManager.RefreshModifiedTextures();
             _3dEngine.CreatePendingSyncs();
             _3dEngine.FlushUboDirty();
-
+            
+            var srcPhysical = memoryManager.GetBackingMemory(srcGpuVa);
+            var dstPhysical = memoryManager.GetBackingMemory(dstGpuVa);
+            
             if (copy2D)
             {
                 // Buffer to texture copy.
@@ -293,7 +296,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Dma
 
                 if (completeSource && completeDest && !srcLinear && isIdentityRemap)
                 {
-                    Image.Texture source = memoryManager.Physical.TextureCache.FindTexture(
+                    Image.Texture source = srcPhysical.TextureCache.FindTexture(
                         memoryManager,
                         srcGpuVa,
                         srcBpp,
@@ -309,7 +312,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Dma
                     {
                         source.SynchronizeMemory();
 
-                        Image.Texture target = memoryManager.Physical.TextureCache.FindOrCreateTexture(
+                        Image.Texture target = dstPhysical.TextureCache.FindOrCreateTexture(
                             memoryManager,
                             source.Info.FormatInfo,
                             dstGpuVa,
@@ -339,7 +342,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Dma
 
                 if (completeSource && completeDest && !(dstLinear && !srcLinear) && isIdentityRemap)
                 {
-                    Image.Texture target = memoryManager.Physical.TextureCache.FindTexture(
+                    Image.Texture target = dstPhysical.TextureCache.FindTexture(
                         memoryManager,
                         dstGpuVa,
                         dstBpp,
@@ -462,6 +465,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Dma
             }
             else
             {
+                var bufferCache = dstPhysical.BufferCache;
                 if (remap &&
                     _state.State.SetRemapComponentsDstX == SetRemapComponentsDst.ConstA &&
                     _state.State.SetRemapComponentsDstY == SetRemapComponentsDst.ConstA &&
@@ -472,7 +476,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Dma
                     _state.State.SetRemapComponentsComponentSize == SetRemapComponentsComponentSize.Four)
                 {
                     // Fast path for clears when remap is enabled.
-                    memoryManager.Physical.BufferCache.ClearBuffer(memoryManager, dstGpuVa, size * 4, _state.State.SetRemapConstA);
+                    bufferCache.ClearBuffer(memoryManager, dstGpuVa, size * 4, _state.State.SetRemapConstA);
                 }
                 else
                 {
@@ -492,7 +496,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Dma
                     }
                     else
                     {
-                        memoryManager.Physical.BufferCache.CopyBuffer(memoryManager, srcGpuVa, dstGpuVa, size);
+                        BufferCache.CopyBuffer(_context,memoryManager, srcGpuVa, dstGpuVa, size);
                     }
                 }
             }

--- a/src/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
@@ -216,8 +216,8 @@ namespace Ryujinx.Graphics.Gpu.Engine.Dma
             _3dEngine.CreatePendingSyncs();
             _3dEngine.FlushUboDirty();
             
-            var srcPhysical = memoryManager.GetBackingMemory(srcGpuVa);
-            var dstPhysical = memoryManager.GetBackingMemory(dstGpuVa);
+            PhysicalMemory srcPhysical = memoryManager.GetBackingMemory(srcGpuVa);
+            PhysicalMemory dstPhysical = memoryManager.GetBackingMemory(dstGpuVa);
             
             if (copy2D)
             {
@@ -465,7 +465,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Dma
             }
             else
             {
-                var bufferCache = dstPhysical.BufferCache;
+                BufferCache bufferCache = dstPhysical.BufferCache;
                 if (remap &&
                     _state.State.SetRemapComponentsDstX == SetRemapComponentsDst.ConstA &&
                     _state.State.SetRemapComponentsDstY == SetRemapComponentsDst.ConstA &&

--- a/src/Ryujinx.Graphics.Gpu/Engine/InlineToMemory/InlineToMemoryClass.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/InlineToMemory/InlineToMemoryClass.cs
@@ -185,7 +185,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.InlineToMemory
                 // Right now the copy code at the bottom assumes that it is used on both which might be incorrect.
                 if (!_isLinear)
                 {
-                    var target = memoryManager.GetBackingMemory(_dstGpuVa).TextureCache.FindTexture(
+                    Image.Texture target = memoryManager.GetBackingMemory(_dstGpuVa).TextureCache.FindTexture(
                         memoryManager,
                         _dstGpuVa,
                         1,

--- a/src/Ryujinx.Graphics.Gpu/Engine/InlineToMemory/InlineToMemoryClass.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/InlineToMemory/InlineToMemoryClass.cs
@@ -185,7 +185,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.InlineToMemory
                 // Right now the copy code at the bottom assumes that it is used on both which might be incorrect.
                 if (!_isLinear)
                 {
-                    Image.Texture target = memoryManager.Physical.TextureCache.FindTexture(
+                    var target = memoryManager.GetBackingMemory(_dstGpuVa).TextureCache.FindTexture(
                         memoryManager,
                         _dstGpuVa,
                         1,

--- a/src/Ryujinx.Graphics.Gpu/Engine/MME/MacroHLE.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/MME/MacroHLE.cs
@@ -493,8 +493,8 @@ namespace Ryujinx.Graphics.Gpu.Engine.MME
                     }
                 }
             }
-            var indirectBufferCache = _processor.MemoryManager.GetBackingMemory(indirectBufferGpuVa).BufferCache;
-            var parameterBufferCache = _processor.MemoryManager.GetBackingMemory(parameterBufferGpuVa).BufferCache;
+            BufferCache indirectBufferCache = _processor.MemoryManager.GetBackingMemory(indirectBufferGpuVa).BufferCache;
+            BufferCache parameterBufferCache = _processor.MemoryManager.GetBackingMemory(parameterBufferGpuVa).BufferCache;
 
             ulong indirectBufferSize = (ulong)maxDrawCount * (ulong)stride;
 

--- a/src/Ryujinx.Graphics.Gpu/Engine/MME/MacroHLE.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/MME/MacroHLE.cs
@@ -384,7 +384,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.MME
 
             ulong indirectBufferGpuVa = count.GpuVa;
 
-            BufferCache bufferCache = _processor.MemoryManager.Physical.BufferCache;
+            BufferCache bufferCache = _processor.MemoryManager.GetBackingMemory(indirectBufferGpuVa).BufferCache;
 
             bool useBuffer = bufferCache.CheckModified(_processor.MemoryManager, indirectBufferGpuVa, IndirectIndexedDataEntrySize, out ulong indirectBufferAddress);
 
@@ -394,6 +394,8 @@ namespace Ryujinx.Graphics.Gpu.Engine.MME
 
                 _processor.ThreedClass.DrawIndirect(
                     topology,
+                    bufferCache,
+                    null,
                     new MultiRange(indirectBufferAddress, IndirectIndexedDataEntrySize),
                     default,
                     1,
@@ -491,22 +493,24 @@ namespace Ryujinx.Graphics.Gpu.Engine.MME
                     }
                 }
             }
-
-            BufferCache bufferCache = _processor.MemoryManager.Physical.BufferCache;
+            var indirectBufferCache = _processor.MemoryManager.GetBackingMemory(indirectBufferGpuVa).BufferCache;
+            var parameterBufferCache = _processor.MemoryManager.GetBackingMemory(parameterBufferGpuVa).BufferCache;
 
             ulong indirectBufferSize = (ulong)maxDrawCount * (ulong)stride;
 
-            MultiRange indirectBufferRange = bufferCache.TranslateAndCreateMultiBuffers(_processor.MemoryManager, indirectBufferGpuVa, indirectBufferSize, BufferStage.Indirect);
-            MultiRange parameterBufferRange = bufferCache.TranslateAndCreateMultiBuffers(_processor.MemoryManager, parameterBufferGpuVa, 4, BufferStage.Indirect);
+            MultiRange indirectBufferRange = indirectBufferCache.TranslateAndCreateMultiBuffers(_processor.MemoryManager, indirectBufferGpuVa, indirectBufferSize, BufferStage.Indirect);
+            MultiRange parameterBufferRange = parameterBufferCache.TranslateAndCreateMultiBuffers(_processor.MemoryManager, parameterBufferGpuVa, 4, BufferStage.Indirect);
 
             _processor.ThreedClass.DrawIndirect(
                 topology,
+                indirectBufferCache,
+                parameterBufferCache,
                 indirectBufferRange,
                 parameterBufferRange,
                 maxDrawCount,
                 stride,
                 indexCount,
-                Threed.IndirectDrawType.DrawIndexedIndirectCount);
+                IndirectDrawType.DrawIndexedIndirectCount);
         }
 
         /// <summary>

--- a/src/Ryujinx.Graphics.Gpu/Engine/Threed/ComputeDraw/VtgAsComputeContext.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/Threed/ComputeDraw/VtgAsComputeContext.cs
@@ -67,7 +67,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed.ComputeDraw
             {
                 if (disposing)
                 {
-                    foreach (var texture in _cache.Values)
+                    foreach (ITexture texture in _cache.Values)
                     {
                         texture.Release();
                     }
@@ -620,7 +620,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed.ComputeDraw
                 DestroyIfNotNull(ref _geometryIndexDataBuffer.Handle);
                 DestroyIfNotNull(ref _sequentialIndexBuffer);
 
-                foreach (var indexBuffer in _topologyRemapBuffers.Values)
+                foreach (IndexBuffer indexBuffer in _topologyRemapBuffers.Values)
                 {
                     _context.Renderer.DeleteBuffer(indexBuffer.Handle);
                 }

--- a/src/Ryujinx.Graphics.Gpu/Engine/Threed/ComputeDraw/VtgAsComputeContext.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/Threed/ComputeDraw/VtgAsComputeContext.cs
@@ -11,6 +11,8 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed.ComputeDraw
     /// </summary>
     class VtgAsComputeContext : IDisposable
     {
+        private const int DummyBufferSize = 16;
+
         private readonly GpuContext _context;
 
         /// <summary>
@@ -46,7 +48,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed.ComputeDraw
                         1,
                         1,
                         1,
-                        format.GetBytesPerElement(),
+                        1,
                         format,
                         DepthStencilMode.Depth,
                         Target.TextureBuffer,
@@ -65,7 +67,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed.ComputeDraw
             {
                 if (disposing)
                 {
-                    foreach (ITexture texture in _cache.Values)
+                    foreach (var texture in _cache.Values)
                     {
                         texture.Release();
                     }
@@ -520,6 +522,21 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed.ComputeDraw
         }
 
         /// <summary>
+        /// Gets the range for a dummy 16 bytes buffer, filled with zeros.
+        /// </summary>
+        /// <returns>Dummy buffer range</returns>
+        public BufferRange GetDummyBufferRange()
+        {
+            if (_dummyBuffer == BufferHandle.Null)
+            {
+                _dummyBuffer = _context.Renderer.CreateBuffer(DummyBufferSize, BufferAccess.DeviceMemory);
+                _context.Renderer.Pipeline.ClearBuffer(_dummyBuffer, 0, DummyBufferSize, 0);
+            }
+
+            return new BufferRange(_dummyBuffer, 0, DummyBufferSize);
+        }
+
+        /// <summary>
         /// Gets the range for a sequential index buffer, with ever incrementing index values.
         /// </summary>
         /// <param name="count">Minimum number of indices that the buffer should have</param>
@@ -603,7 +620,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed.ComputeDraw
                 DestroyIfNotNull(ref _geometryIndexDataBuffer.Handle);
                 DestroyIfNotNull(ref _sequentialIndexBuffer);
 
-                foreach (IndexBuffer indexBuffer in _topologyRemapBuffers.Values)
+                foreach (var indexBuffer in _topologyRemapBuffers.Values)
                 {
                     _context.Renderer.DeleteBuffer(indexBuffer.Handle);
                 }

--- a/src/Ryujinx.Graphics.Gpu/Engine/Threed/ComputeDraw/VtgAsComputeState.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/Threed/ComputeDraw/VtgAsComputeState.cs
@@ -127,7 +127,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed.ComputeDraw
 
             for (int index = 0; index < Constants.TotalVertexAttribs; index++)
             {
-                var vertexAttrib = _state.State.VertexAttribState[index];
+                VertexAttribState vertexAttrib = _state.State.VertexAttribState[index];
 
                 if (!FormatTable.TryGetSingleComponentAttribFormat(vertexAttrib.UnpackFormat(), out Format format, out int componentsCount))
                 {
@@ -154,7 +154,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed.ComputeDraw
                 int bufferIndex = vertexAttrib.UnpackBufferIndex();
 
                 GpuVa endAddress = _state.State.VertexBufferEndAddress[bufferIndex];
-                var vertexBuffer = _state.State.VertexBufferState[bufferIndex];
+                VertexBufferState vertexBuffer = _state.State.VertexBufferState[bufferIndex];
                 bool instanced = _state.State.VertexBufferInstanced[bufferIndex];
 
                 ulong address = vertexBuffer.Address.Pack();
@@ -369,7 +369,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed.ComputeDraw
         /// <param name="size">Size of the buffer in bytes</param>
         private readonly void SetBufferTexture(ResourceReservations reservations, int index, Format format, ulong address, ulong size)
         {
-            var memoryManager = _channel.MemoryManager;
+            MemoryManager memoryManager = _channel.MemoryManager;
 
             BufferRange range = memoryManager.GetBackingMemory(address).BufferCache.GetBufferRange(memoryManager.GetPhysicalRegions(address, size), BufferStage.VertexBuffer);
 
@@ -410,7 +410,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed.ComputeDraw
             indexOffset <<= shift;
             size <<= shift;
 
-            var memoryManager = _channel.MemoryManager;
+            MemoryManager memoryManager = _channel.MemoryManager;
 
             ulong misalign = address & ((ulong)_context.Capabilities.TextureBufferOffsetAlignment - 1);
             BufferRange range = memoryManager.GetBackingMemory(address).BufferCache.GetBufferRange(

--- a/src/Ryujinx.Graphics.Gpu/Engine/Threed/ComputeDraw/VtgAsComputeState.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/Threed/ComputeDraw/VtgAsComputeState.cs
@@ -127,7 +127,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed.ComputeDraw
 
             for (int index = 0; index < Constants.TotalVertexAttribs; index++)
             {
-                VertexAttribState vertexAttrib = _state.State.VertexAttribState[index];
+                var vertexAttrib = _state.State.VertexAttribState[index];
 
                 if (!FormatTable.TryGetSingleComponentAttribFormat(vertexAttrib.UnpackFormat(), out Format format, out int componentsCount))
                 {
@@ -147,13 +147,14 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed.ComputeDraw
                 {
                     _vacContext.VertexInfoBufferUpdater.SetVertexStride(index, 0, componentsCount);
                     _vacContext.VertexInfoBufferUpdater.SetVertexOffset(index, 0, 0);
+                    SetDummyBufferTexture(_vertexAsCompute.Reservations, index, format);
                     continue;
                 }
 
                 int bufferIndex = vertexAttrib.UnpackBufferIndex();
 
                 GpuVa endAddress = _state.State.VertexBufferEndAddress[bufferIndex];
-                VertexBufferState vertexBuffer = _state.State.VertexBufferState[bufferIndex];
+                var vertexBuffer = _state.State.VertexBufferState[bufferIndex];
                 bool instanced = _state.State.VertexBufferInstanced[bufferIndex];
 
                 ulong address = vertexBuffer.Address.Pack();
@@ -162,11 +163,14 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed.ComputeDraw
                 {
                     _vacContext.VertexInfoBufferUpdater.SetVertexStride(index, 0, componentsCount);
                     _vacContext.VertexInfoBufferUpdater.SetVertexOffset(index, 0, 0);
+                    SetDummyBufferTexture(_vertexAsCompute.Reservations, index, format);
                     continue;
                 }
 
                 int vbStride = vertexBuffer.UnpackStride();
                 ulong vbSize = GetVertexBufferSize(address, endAddress.Pack(), vbStride, _indexed, instanced, _firstVertex, _count);
+
+                ulong oldVbSize = vbSize;
 
                 ulong attributeOffset = (ulong)vertexAttrib.UnpackOffset();
                 int componentSize = format.GetScalarSize();
@@ -196,11 +200,11 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed.ComputeDraw
 
             int vertexInfoBinding = _vertexAsCompute.Reservations.VertexInfoConstantBufferBinding;
             BufferRange vertexInfoRange = new(_vacContext.VertexInfoBufferUpdater.Handle, 0, VertexInfoBuffer.RequiredSize);
-            _context.Renderer.Pipeline.SetUniformBuffers([new BufferAssignment(vertexInfoBinding, vertexInfoRange)]);
+            _context.Renderer.Pipeline.SetUniformBuffers(stackalloc[] { new BufferAssignment(vertexInfoBinding, vertexInfoRange) });
 
             int vertexDataBinding = _vertexAsCompute.Reservations.VertexOutputStorageBufferBinding;
             BufferRange vertexDataRange = _vacContext.GetVertexDataBufferRange(_vertexDataOffset, _vertexDataSize, write: true);
-            _context.Renderer.Pipeline.SetStorageBuffers([new BufferAssignment(vertexDataBinding, vertexDataRange)]);
+            _context.Renderer.Pipeline.SetStorageBuffers(stackalloc[] { new BufferAssignment(vertexDataBinding, vertexDataRange) });
 
             _vacContext.VertexInfoBufferUpdater.Commit();
 
@@ -228,7 +232,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed.ComputeDraw
 
             int vertexInfoBinding = _vertexAsCompute.Reservations.VertexInfoConstantBufferBinding;
             BufferRange vertexInfoRange = new(_vacContext.VertexInfoBufferUpdater.Handle, 0, VertexInfoBuffer.RequiredSize);
-            _context.Renderer.Pipeline.SetUniformBuffers([new BufferAssignment(vertexInfoBinding, vertexInfoRange)]);
+            _context.Renderer.Pipeline.SetUniformBuffers(stackalloc[] { new BufferAssignment(vertexInfoBinding, vertexInfoRange) });
 
             int vertexDataBinding = _vertexAsCompute.Reservations.VertexOutputStorageBufferBinding;
 
@@ -246,11 +250,12 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed.ComputeDraw
             BufferRange vertexBuffer = _vacContext.GetGeometryVertexDataBufferRange(_geometryVertexDataOffset, _geometryVertexDataSize, write: true);
             BufferRange indexBuffer = _vacContext.GetGeometryIndexDataBufferRange(_geometryIndexDataOffset, _geometryIndexDataSize, write: true);
 
-            _context.Renderer.Pipeline.SetStorageBuffers([
+            _context.Renderer.Pipeline.SetStorageBuffers(stackalloc[]
+            {
                 new BufferAssignment(vertexDataBinding, vertexDataRange),
                 new BufferAssignment(geometryVbBinding, vertexBuffer),
-                new BufferAssignment(geometryIbBinding, indexBuffer)
-            ]);
+                new BufferAssignment(geometryIbBinding, indexBuffer),
+            });
 
             _context.Renderer.Pipeline.DispatchCompute(
                 BitUtils.DivRoundUp(primitivesCount, ComputeLocalSize),
@@ -294,7 +299,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed.ComputeDraw
 
                 _context.Renderer.Pipeline.SetProgram(_vertexPassthroughProgram);
                 _context.Renderer.Pipeline.SetIndexBuffer(indexBuffer, IndexType.UInt);
-                _context.Renderer.Pipeline.SetStorageBuffers([new BufferAssignment(vertexDataBinding, vertexBuffer)]);
+                _context.Renderer.Pipeline.SetStorageBuffers(stackalloc[] { new BufferAssignment(vertexDataBinding, vertexBuffer) });
 
                 _context.Renderer.Pipeline.SetPrimitiveRestart(true, -1);
                 _context.Renderer.Pipeline.SetPrimitiveTopology(GetGeometryOutputTopology(_geometryAsCompute.Info.GeometryVerticesPerPrimitive));
@@ -309,7 +314,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed.ComputeDraw
                 BufferRange vertexDataRange = _vacContext.GetVertexDataBufferRange(_vertexDataOffset, _vertexDataSize, write: false);
 
                 _context.Renderer.Pipeline.SetProgram(_vertexPassthroughProgram);
-                _context.Renderer.Pipeline.SetStorageBuffers([new BufferAssignment(vertexDataBinding, vertexDataRange)]);
+                _context.Renderer.Pipeline.SetStorageBuffers(stackalloc[] { new BufferAssignment(vertexDataBinding, vertexDataRange) });
                 _context.Renderer.Pipeline.Draw(_count, _instanceCount, 0, 0);
             }
         }
@@ -341,6 +346,20 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed.ComputeDraw
         }
 
         /// <summary>
+        /// Binds a dummy buffer as vertex buffer into a buffer texture.
+        /// </summary>
+        /// <param name="reservations">Shader resource binding reservations</param>
+        /// <param name="index">Buffer texture index</param>
+        /// <param name="format">Buffer texture format</param>
+        private readonly void SetDummyBufferTexture(ResourceReservations reservations, int index, Format format)
+        {
+            ITexture bufferTexture = _vacContext.EnsureBufferTexture(index + 2, format);
+            bufferTexture.SetStorage(_vacContext.GetDummyBufferRange());
+
+            _context.Renderer.Pipeline.SetTextureAndSampler(ShaderStage.Compute, reservations.GetVertexBufferTextureBinding(index), bufferTexture, null);
+        }
+
+        /// <summary>
         /// Binds a vertex buffer into a buffer texture.
         /// </summary>
         /// <param name="reservations">Shader resource binding reservations</param>
@@ -350,9 +369,9 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed.ComputeDraw
         /// <param name="size">Size of the buffer in bytes</param>
         private readonly void SetBufferTexture(ResourceReservations reservations, int index, Format format, ulong address, ulong size)
         {
-            MemoryManager memoryManager = _channel.MemoryManager;
+            var memoryManager = _channel.MemoryManager;
 
-            BufferRange range = memoryManager.Physical.BufferCache.GetBufferRange(memoryManager.GetPhysicalRegions(address, size), BufferStage.VertexBuffer);
+            BufferRange range = memoryManager.GetBackingMemory(address).BufferCache.GetBufferRange(memoryManager.GetPhysicalRegions(address, size), BufferStage.VertexBuffer);
 
             ITexture bufferTexture = _vacContext.EnsureBufferTexture(index + 2, format);
             bufferTexture.SetStorage(range);
@@ -391,10 +410,10 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed.ComputeDraw
             indexOffset <<= shift;
             size <<= shift;
 
-            MemoryManager memoryManager = _channel.MemoryManager;
+            var memoryManager = _channel.MemoryManager;
 
             ulong misalign = address & ((ulong)_context.Capabilities.TextureBufferOffsetAlignment - 1);
-            BufferRange range = memoryManager.Physical.BufferCache.GetBufferRange(
+            BufferRange range = memoryManager.GetBackingMemory(address).BufferCache.GetBufferRange(
                 memoryManager.GetPhysicalRegions(address + indexOffset - misalign, size + misalign),
                 BufferStage.IndexBuffer);
             misalignedOffset = (int)misalign >> shift;

--- a/src/Ryujinx.Graphics.Gpu/Engine/Threed/ConstantBufferUpdater.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/Threed/ConstantBufferUpdater.cs
@@ -114,7 +114,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
             if (_ubFollowUpAddress != 0)
             {
                 MemoryManager memoryManager = _channel.MemoryManager;
-                var physicalMemory = memoryManager.GetBackingMemory(_ubBeginGpuAddress);
+                PhysicalMemory physicalMemory = memoryManager.GetBackingMemory(_ubBeginGpuAddress);
 
                 Span<byte> data = MemoryMarshal.Cast<int, byte>(_ubData.AsSpan(0, (int)(_ubByteCount / 4)));
 

--- a/src/Ryujinx.Graphics.Gpu/Engine/Threed/ConstantBufferUpdater.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/Threed/ConstantBufferUpdater.cs
@@ -16,6 +16,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
 
         // State associated with direct uniform buffer updates.
         // This state is used to attempt to batch together consecutive updates.
+        private ulong _ubBeginGpuAddress = 0;
         private ulong _ubBeginCpuAddress = 0;
         private ulong _ubFollowUpAddress = 0;
         private ulong _ubByteCount = 0;
@@ -113,12 +114,13 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
             if (_ubFollowUpAddress != 0)
             {
                 MemoryManager memoryManager = _channel.MemoryManager;
+                var physicalMemory = memoryManager.GetBackingMemory(_ubBeginGpuAddress);
 
                 Span<byte> data = MemoryMarshal.Cast<int, byte>(_ubData.AsSpan(0, (int)(_ubByteCount / 4)));
 
-                if (memoryManager.Physical.WriteWithRedundancyCheck(_ubBeginCpuAddress, data))
+                if (physicalMemory.WriteWithRedundancyCheck(_ubBeginCpuAddress, data))
                 {
-                    memoryManager.Physical.BufferCache.ForceDirty(memoryManager, _ubFollowUpAddress - _ubByteCount, _ubByteCount);
+                    physicalMemory.BufferCache.ForceDirty(memoryManager, _ubFollowUpAddress - _ubByteCount, _ubByteCount);
                 }
 
                 _ubFollowUpAddress = 0;

--- a/src/Ryujinx.Graphics.Gpu/Engine/Threed/DrawManager.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/Threed/DrawManager.cs
@@ -641,6 +641,8 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
         public void DrawIndirect(
             ThreedClass engine,
             PrimitiveTopology topology,
+            BufferCache indirectBufferCache,
+            BufferCache parameterBufferCache,
             MultiRange indirectBufferRange,
             MultiRange parameterBufferRange,
             int maxDrawCount,
@@ -662,8 +664,6 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
                 return;
             }
 
-            PhysicalMemory memory = _channel.MemoryManager.Physical;
-
             bool hasCount = (drawType & IndirectDrawType.Count) != 0;
             bool indexed = (drawType & IndirectDrawType.Indexed) != 0;
 
@@ -684,8 +684,8 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
 
             if (hasCount)
             {
-                BufferRange indirectBuffer = memory.BufferCache.GetBufferRange(indirectBufferRange, BufferStage.Indirect);
-                BufferRange parameterBuffer = memory.BufferCache.GetBufferRange(parameterBufferRange, BufferStage.Indirect);
+                BufferRange indirectBuffer = indirectBufferCache.GetBufferRange(indirectBufferRange, BufferStage.Indirect);
+                BufferRange parameterBuffer = parameterBufferCache.GetBufferRange(parameterBufferRange, BufferStage.Indirect);
 
                 if (indexed)
                 {
@@ -698,7 +698,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
             }
             else
             {
-                BufferRange indirectBuffer = memory.BufferCache.GetBufferRange(indirectBufferRange, BufferStage.Indirect);
+                BufferRange indirectBuffer = indirectBufferCache.GetBufferRange(indirectBufferRange, BufferStage.Indirect);
 
                 if (indexed)
                 {

--- a/src/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
@@ -381,7 +381,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
                 {
                     BufferDescriptor sb = info.SBuffers[index];
 
-                    (var physical, ulong sbDescAddress) = _channel.BufferManager.GetGraphicsUniformBufferAddress(stage, sb.SbCbSlot);
+                    (PhysicalMemory physical, ulong sbDescAddress) = _channel.BufferManager.GetGraphicsUniformBufferAddress(stage, sb.SbCbSlot);
                     sbDescAddress += (ulong)sb.SbCbOffset * 4;
 
                     SbDescriptor sbDescriptor = physical.Read<SbDescriptor>(sbDescAddress);
@@ -505,7 +505,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
                     rtNoAlphaMask |= 1u << index;
                 }
 
-                var colorTextureCache = memoryManager.GetBackingMemory(colorState.Address.Pack()).TextureCache;
+                TextureCache colorTextureCache = memoryManager.GetBackingMemory(colorState.Address.Pack()).TextureCache;
 
                 Image.Texture color = colorTextureCache.FindOrCreateTexture(
                     memoryManager,
@@ -545,7 +545,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
             {
                 RtDepthStencilState dsState = _state.State.RtDepthStencilState;
                 Size3D dsSize = _state.State.RtDepthStencilSize;
-                var dsTextureCache = memoryManager.GetBackingMemory(dsState.Address.Pack()).TextureCache;
+                TextureCache dsTextureCache = memoryManager.GetBackingMemory(dsState.Address.Pack()).TextureCache;
                 
                 depthStencil = dsTextureCache.FindOrCreateTexture(
                     memoryManager,
@@ -1436,7 +1436,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
 
             // Shader stages on different address spaces are not supported right now,
             // but it should never happen in practice anyway.
-            var shaderCache = _channel.MemoryManager.GetBackingMemory(addresses.VertexB).ShaderCache;
+            ShaderCache shaderCache = _channel.MemoryManager.GetBackingMemory(addresses.VertexB).ShaderCache;
             CachedShaderProgram gs = shaderCache.GetGraphicsShader(
                 ref _state.State,
                 ref _pipeline,

--- a/src/Ryujinx.Graphics.Gpu/Engine/Threed/ThreedClass.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/Threed/ThreedClass.cs
@@ -5,6 +5,7 @@ using Ryujinx.Graphics.Gpu.Engine.GPFifo;
 using Ryujinx.Graphics.Gpu.Engine.InlineToMemory;
 using Ryujinx.Graphics.Gpu.Engine.Threed.Blender;
 using Ryujinx.Graphics.Gpu.Engine.Types;
+using Ryujinx.Graphics.Gpu.Memory;
 using Ryujinx.Graphics.Gpu.Synchronization;
 using Ryujinx.Memory.Range;
 using System;
@@ -804,6 +805,8 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
         /// Performs a indirect draw, with parameters from a GPU buffer.
         /// </summary>
         /// <param name="topology">Primitive topology</param>
+        /// <param name="indirectBufferCache">Buffer cache owning the buffer with the draw parameters</param>
+        /// <param name="parameterBufferCache">Buffer cache owning the buffer with the draw count</param>
         /// <param name="indirectBufferRange">Memory range of the buffer with the draw parameters, such as count, first index, etc</param>
         /// <param name="parameterBufferRange">Memory range of the buffer with the draw count</param>
         /// <param name="maxDrawCount">Maximum number of draws that can be made</param>
@@ -812,6 +815,8 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
         /// <param name="drawType">Type of the indirect draw, which can be indexed or non-indexed, with or without a draw count</param>
         public void DrawIndirect(
             PrimitiveTopology topology,
+            BufferCache indirectBufferCache,
+            BufferCache parameterBufferCache,
             MultiRange indirectBufferRange,
             MultiRange parameterBufferRange,
             int maxDrawCount,
@@ -819,7 +824,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
             int indexCount,
             IndirectDrawType drawType)
         {
-            _drawManager.DrawIndirect(this, topology, indirectBufferRange, parameterBufferRange, maxDrawCount, stride, indexCount, drawType);
+            _drawManager.DrawIndirect(this, topology, indirectBufferCache, parameterBufferCache, indirectBufferRange, parameterBufferRange, maxDrawCount, stride, indexCount, drawType);
         }
 
         /// <summary>

--- a/src/Ryujinx.Graphics.Gpu/Engine/Twod/TwodClass.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/Twod/TwodClass.cs
@@ -233,6 +233,9 @@ namespace Ryujinx.Graphics.Gpu.Engine.Twod
 
             TwodTexture dstCopyTexture = Unsafe.As<uint, TwodTexture>(ref _state.State.SetDstFormat);
             TwodTexture srcCopyTexture = Unsafe.As<uint, TwodTexture>(ref _state.State.SetSrcFormat);
+            
+            var srcTextureCache = memoryManager.GetBackingMemory(srcCopyTexture.Address.Pack()).TextureCache;
+            var dstTextureCache = memoryManager.GetBackingMemory(dstCopyTexture.Address.Pack()).TextureCache;
 
             long srcX = ((long)_state.State.SetPixelsFromMemorySrcX0Int << 32) | (long)(ulong)_state.State.SetPixelsFromMemorySrcX0Frac;
             long srcY = ((long)_state.State.PixelsFromMemorySrcY0Int << 32) | (long)(ulong)_state.State.SetPixelsFromMemorySrcY0Frac;
@@ -305,7 +308,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Twod
             // are the same, as we can't blit between different depth formats.
             bool srcDepthAlias = srcCopyTexture.Format == dstCopyTexture.Format;
 
-            Image.Texture srcTexture = memoryManager.Physical.TextureCache.FindOrCreateTexture(
+            Image.Texture srcTexture = srcTextureCache.FindOrCreateTexture(
                 memoryManager,
                 srcCopyTexture,
                 offset,
@@ -326,7 +329,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Twod
                 return;
             }
 
-            memoryManager.Physical.TextureCache.Lift(srcTexture);
+            srcTextureCache.Lift(srcTexture);
 
             // When the source texture that was found has a depth format,
             // we must enforce the target texture also has a depth format,
@@ -342,7 +345,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Twod
                 dstCopyTextureFormat = dstCopyTexture.Format.Convert();
             }
 
-            Image.Texture dstTexture = memoryManager.Physical.TextureCache.FindOrCreateTexture(
+            Image.Texture dstTexture = dstTextureCache.FindOrCreateTexture(
                 memoryManager,
                 dstCopyTexture,
                 0,

--- a/src/Ryujinx.Graphics.Gpu/Engine/Twod/TwodClass.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/Twod/TwodClass.cs
@@ -234,8 +234,8 @@ namespace Ryujinx.Graphics.Gpu.Engine.Twod
             TwodTexture dstCopyTexture = Unsafe.As<uint, TwodTexture>(ref _state.State.SetDstFormat);
             TwodTexture srcCopyTexture = Unsafe.As<uint, TwodTexture>(ref _state.State.SetSrcFormat);
             
-            var srcTextureCache = memoryManager.GetBackingMemory(srcCopyTexture.Address.Pack()).TextureCache;
-            var dstTextureCache = memoryManager.GetBackingMemory(dstCopyTexture.Address.Pack()).TextureCache;
+            TextureCache srcTextureCache = memoryManager.GetBackingMemory(srcCopyTexture.Address.Pack()).TextureCache;
+            TextureCache dstTextureCache = memoryManager.GetBackingMemory(dstCopyTexture.Address.Pack()).TextureCache;
 
             long srcX = ((long)_state.State.SetPixelsFromMemorySrcX0Int << 32) | (long)(ulong)_state.State.SetPixelsFromMemorySrcX0Frac;
             long srcY = ((long)_state.State.PixelsFromMemorySrcY0Int << 32) | (long)(ulong)_state.State.SetPixelsFromMemorySrcY0Frac;

--- a/src/Ryujinx.Graphics.Gpu/GpuChannel.cs
+++ b/src/Ryujinx.Graphics.Gpu/GpuChannel.cs
@@ -58,22 +58,24 @@ namespace Ryujinx.Graphics.Gpu
         public void BindMemory(MemoryManager memoryManager)
         {
             MemoryManager oldMemoryManager = Interlocked.Exchange(ref _memoryManager, memoryManager ?? throw new ArgumentNullException(nameof(memoryManager)));
+            if (oldMemoryManager == memoryManager)
+            {
+                return;
+            }
 
-            memoryManager.Physical.IncrementReferenceCount();
+            memoryManager.AttachToChannel(BufferManager.Rebind);
 
             if (oldMemoryManager != null)
             {
-                oldMemoryManager.Physical.BufferCache.NotifyBuffersModified -= BufferManager.Rebind;
-                oldMemoryManager.Physical.DecrementReferenceCount();
+                oldMemoryManager.DetachFromChannel(BufferManager.Rebind);
                 oldMemoryManager.MemoryUnmapped -= MemoryUnmappedHandler;
             }
 
-            memoryManager.Physical.BufferCache.NotifyBuffersModified += BufferManager.Rebind;
             memoryManager.MemoryUnmapped += MemoryUnmappedHandler;
 
             // Since the memory manager changed, make sure we will get pools from addresses of the new memory manager.
             TextureManager.ReloadPools();
-            memoryManager.Physical.BufferCache.QueuePrune();
+            memoryManager.QueuePrune();
         }
 
         /// <summary>
@@ -86,7 +88,7 @@ namespace Ryujinx.Graphics.Gpu
             TextureManager.ReloadPools();
 
             MemoryManager memoryManager = Volatile.Read(ref _memoryManager);
-            memoryManager?.Physical.BufferCache.QueuePrune();
+            memoryManager?.QueuePrune();
         }
 
         /// <summary>
@@ -138,11 +140,10 @@ namespace Ryujinx.Graphics.Gpu
             _processor.Dispose();
             TextureManager.Dispose();
 
-            MemoryManager oldMemoryManager = Interlocked.Exchange(ref _memoryManager, null);
+            var oldMemoryManager = Interlocked.Exchange(ref _memoryManager, null);
             if (oldMemoryManager != null)
             {
-                oldMemoryManager.Physical.BufferCache.NotifyBuffersModified -= BufferManager.Rebind;
-                oldMemoryManager.Physical.DecrementReferenceCount();
+                oldMemoryManager.DetachFromChannel(BufferManager.Rebind);
                 oldMemoryManager.MemoryUnmapped -= MemoryUnmappedHandler;
             }
         }

--- a/src/Ryujinx.Graphics.Gpu/GpuChannel.cs
+++ b/src/Ryujinx.Graphics.Gpu/GpuChannel.cs
@@ -140,7 +140,7 @@ namespace Ryujinx.Graphics.Gpu
             _processor.Dispose();
             TextureManager.Dispose();
 
-            var oldMemoryManager = Interlocked.Exchange(ref _memoryManager, null);
+            MemoryManager oldMemoryManager = Interlocked.Exchange(ref _memoryManager, null);
             if (oldMemoryManager != null)
             {
                 oldMemoryManager.DetachFromChannel(BufferManager.Rebind);

--- a/src/Ryujinx.Graphics.Gpu/GpuContext.cs
+++ b/src/Ryujinx.Graphics.Gpu/GpuContext.cs
@@ -6,6 +6,7 @@ using Ryujinx.Graphics.Gpu.Engine.GPFifo;
 using Ryujinx.Graphics.Gpu.Memory;
 using Ryujinx.Graphics.Gpu.Shader;
 using Ryujinx.Graphics.Gpu.Synchronization;
+using Ryujinx.Memory;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -172,7 +173,7 @@ namespace Ryujinx.Graphics.Gpu
                 throw new ArgumentException("The PID is invalid or the process was not registered", nameof(pid));
             }
 
-            return new MemoryManager(physicalMemory, cpuMemorySize);
+            return new MemoryManager(this, physicalMemory, cpuMemorySize);
         }
 
         /// <summary>
@@ -197,7 +198,7 @@ namespace Ryujinx.Graphics.Gpu
         /// <param name="pid">ID of the process that owns <paramref name="cpuMemory"/></param>
         /// <param name="cpuMemory">Virtual memory owned by the process</param>
         /// <exception cref="ArgumentException">Thrown if <paramref name="pid"/> was already registered</exception>
-        public void RegisterProcess(ulong pid, Cpu.IVirtualMemoryManagerTracked cpuMemory)
+        public void RegisterProcess(ulong pid, IVirtualMemoryManagerTracked cpuMemory)
         {
             PhysicalMemory physicalMemory = new(this, cpuMemory);
             if (!PhysicalMemoryRegistry.TryAdd(pid, physicalMemory))

--- a/src/Ryujinx.Graphics.Gpu/Image/PoolCache.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/PoolCache.cs
@@ -1,3 +1,4 @@
+using Ryujinx.Graphics.Gpu.Memory;
 using System;
 using System.Collections.Generic;
 
@@ -64,7 +65,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="maximumId">Maximum ID of the texture pool</param>
         /// <param name="bindingsArrayCache">Cache of texture array bindings</param>
         /// <returns>The found or newly created texture pool</returns>
-        public T FindOrCreate(GpuChannel channel, ulong address, int maximumId, TextureBindingsArrayCache bindingsArrayCache)
+        public T FindOrCreate(GpuChannel channel, PhysicalMemory physicalMemory, ulong address, int maximumId, TextureBindingsArrayCache bindingsArrayCache)
         {
             // Remove old entries from the cache, if possible.
             while (_pools.Count > MaxCapacity && (_currentTimestamp - _pools.First.Value.CacheTimestamp) >= MinDeltaForRemoval)
@@ -99,7 +100,7 @@ namespace Ryujinx.Graphics.Gpu.Image
             }
 
             // If not found, create a new one.
-            pool = CreatePool(_context, channel, address, maximumId);
+            pool = CreatePool(_context, channel, physicalMemory, address, maximumId);
 
             pool.CacheNode = _pools.AddLast(pool);
             pool.CacheTimestamp = _currentTimestamp;
@@ -114,7 +115,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="channel">GPU channel that the pool belongs to</param>
         /// <param name="address">Address of the pool in guest memory</param>
         /// <param name="maximumId">Maximum ID of the pool (equal to maximum minus one)</param>
-        protected abstract T CreatePool(GpuContext context, GpuChannel channel, ulong address, int maximumId);
+        protected abstract T CreatePool(GpuContext context, GpuChannel channel, PhysicalMemory physical, ulong address, int maximumId);
 
         public void Dispose()
         {

--- a/src/Ryujinx.Graphics.Gpu/Image/PoolCache.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/PoolCache.cs
@@ -113,9 +113,10 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// </summary>
         /// <param name="context">GPU context that the pool belongs to</param>
         /// <param name="channel">GPU channel that the pool belongs to</param>
+        /// <param name="physicalMemory">GPU backing memory of the pool</param>
         /// <param name="address">Address of the pool in guest memory</param>
         /// <param name="maximumId">Maximum ID of the pool (equal to maximum minus one)</param>
-        protected abstract T CreatePool(GpuContext context, GpuChannel channel, PhysicalMemory physical, ulong address, int maximumId);
+        protected abstract T CreatePool(GpuContext context, GpuChannel channel, PhysicalMemory physicalMemory, ulong address, int maximumId);
 
         public void Dispose()
         {

--- a/src/Ryujinx.Graphics.Gpu/Image/SamplerPoolCache.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/SamplerPoolCache.cs
@@ -1,3 +1,5 @@
+using Ryujinx.Graphics.Gpu.Memory;
+
 namespace Ryujinx.Graphics.Gpu.Image
 {
     /// <summary>
@@ -22,9 +24,9 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="channel">GPU channel that the texture pool belongs to</param>
         /// <param name="address">Address of the sampler pool in guest memory</param>
         /// <param name="maximumId">Maximum sampler ID of the sampler pool (equal to maximum samplers minus one)</param>
-        protected override SamplerPool CreatePool(GpuContext context, GpuChannel channel, ulong address, int maximumId)
+        protected override SamplerPool CreatePool(GpuContext context, GpuChannel channel, PhysicalMemory physicalMemory, ulong address, int maximumId)
         {
-            return new SamplerPool(context, channel.MemoryManager.Physical, address, maximumId);
+            return new SamplerPool(context, physicalMemory, address, maximumId);
         }
     }
 }

--- a/src/Ryujinx.Graphics.Gpu/Image/SamplerPoolCache.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/SamplerPoolCache.cs
@@ -22,6 +22,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// </summary>
         /// <param name="context">GPU context that the sampler pool belongs to</param>
         /// <param name="channel">GPU channel that the texture pool belongs to</param>
+        /// <param name="physicalMemory">GPU backing memory of the pool</param>
         /// <param name="address">Address of the sampler pool in guest memory</param>
         /// <param name="maximumId">Maximum sampler ID of the sampler pool (equal to maximum samplers minus one)</param>
         protected override SamplerPool CreatePool(GpuContext context, GpuChannel channel, PhysicalMemory physicalMemory, ulong address, int maximumId)

--- a/src/Ryujinx.Graphics.Gpu/Image/TextureBindingsArrayCache.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TextureBindingsArrayCache.cs
@@ -900,7 +900,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                 if (hostTexture != null && texture.Target == Target.TextureBuffer)
                 {
-                    var bufferCache = textureBufferBounds.BufferCache;
+                    BufferCache bufferCache = textureBufferBounds.BufferCache;
                     
                     // Ensure that the buffer texture is using the correct buffer as storage.
                     // Buffers are frequently re-created to accommodate larger data, so we need to re-bind

--- a/src/Ryujinx.Graphics.Gpu/Image/TextureBindingsArrayCache.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TextureBindingsArrayCache.cs
@@ -660,6 +660,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             ISampler[] samplers = isImage ? null : new ISampler[bindingInfo.ArrayLength];
             ITexture[] textures = new ITexture[bindingInfo.ArrayLength];
+            BufferCache bufferCache = null;
 
             for (int index = 0; index < length; index++)
             {
@@ -673,7 +674,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 else
                 {
                     ref readonly TextureDescriptor descriptor = ref texturePool.GetForBinding(index, bindingInfo.FormatInfo, out texture);
-
+                    bufferCache = _channel.MemoryManager.GetBackingMemory(descriptor.UnpackAddress()).BufferCache;
                     if (texture != null)
                     {
                         entry.Textures[texture] = texture.InvalidatedSequence;
@@ -702,11 +703,10 @@ namespace Ryujinx.Graphics.Gpu.Image
                     // to ensure we're not using a old buffer that was already deleted.
                     if (isImage)
                     {
-                        _channel.BufferManager.SetBufferTextureStorage(stage, entry.ImageArray, hostTexture, texture.Range, bindingInfo, index);
-                    }
+                        _channel.BufferManager.SetBufferTextureStorage(stage, entry.ImageArray, hostTexture, bufferCache, texture.Range, bindingInfo, index);                    }
                     else
                     {
-                        _channel.BufferManager.SetBufferTextureStorage(stage, entry.TextureArray, hostTexture, texture.Range, bindingInfo, index);
+                        _channel.BufferManager.SetBufferTextureStorage(stage, entry.TextureArray, hostTexture, bufferCache, texture.Range, bindingInfo, index);
                     }
                 }
                 else if (isImage)
@@ -797,11 +797,11 @@ namespace Ryujinx.Graphics.Gpu.Image
                     return;
                 }
 
-                cachedTextureBuffer = MemoryMarshal.Cast<byte, int>(_channel.MemoryManager.Physical.GetSpan(textureBufferBounds.Range));
-
+                cachedTextureBuffer = MemoryMarshal.Cast<byte, int>(textureBufferBounds.Physical.GetSpan(textureBufferBounds.Range));
+                
                 if (separateSamplerBuffer)
                 {
-                    cachedSamplerBuffer = MemoryMarshal.Cast<byte, int>(_channel.MemoryManager.Physical.GetSpan(samplerBufferBounds.Range));
+                    cachedSamplerBuffer = MemoryMarshal.Cast<byte, int>(samplerBufferBounds.Physical.GetSpan(samplerBufferBounds.Range));
                 }
                 else
                 {
@@ -828,11 +828,10 @@ namespace Ryujinx.Graphics.Gpu.Image
             }
             else
             {
-                cachedTextureBuffer = MemoryMarshal.Cast<byte, int>(_channel.MemoryManager.Physical.GetSpan(textureBufferBounds.Range));
-
+                cachedTextureBuffer = MemoryMarshal.Cast<byte, int>(textureBufferBounds.Physical.GetSpan(textureBufferBounds.Range));
                 if (separateSamplerBuffer)
                 {
-                    cachedSamplerBuffer = MemoryMarshal.Cast<byte, int>(_channel.MemoryManager.Physical.GetSpan(samplerBufferBounds.Range));
+                    cachedSamplerBuffer = MemoryMarshal.Cast<byte, int>(samplerBufferBounds.Physical.GetSpan(samplerBufferBounds.Range));
                 }
                 else
                 {
@@ -901,16 +900,18 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                 if (hostTexture != null && texture.Target == Target.TextureBuffer)
                 {
+                    var bufferCache = textureBufferBounds.BufferCache;
+                    
                     // Ensure that the buffer texture is using the correct buffer as storage.
                     // Buffers are frequently re-created to accommodate larger data, so we need to re-bind
                     // to ensure we're not using a old buffer that was already deleted.
                     if (isImage)
                     {
-                        _channel.BufferManager.SetBufferTextureStorage(stage, entry.ImageArray, hostTexture, texture.Range, bindingInfo, index);
+                        _channel.BufferManager.SetBufferTextureStorage(stage, entry.ImageArray, hostTexture, bufferCache, texture.Range, bindingInfo, index);
                     }
                     else
                     {
-                        _channel.BufferManager.SetBufferTextureStorage(stage, entry.TextureArray, hostTexture, texture.Range, bindingInfo, index);
+                        _channel.BufferManager.SetBufferTextureStorage(stage, entry.TextureArray, hostTexture, bufferCache, texture.Range, bindingInfo, index);
                     }
                 }
                 else if (isImage)

--- a/src/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
@@ -524,7 +524,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                     // Ensure that the buffer texture is using the correct buffer as storage.
                     // Buffers are frequently re-created to accommodate larger data, so we need to re-bind
                     // to ensure we're not using a old buffer that was already deleted.
-                    var bufferCache = _channel.MemoryManager.GetBackingMemory(descriptor.UnpackAddress()).BufferCache;
+                    BufferCache bufferCache = _channel.MemoryManager.GetBackingMemory(descriptor.UnpackAddress()).BufferCache;
                     _channel.BufferManager.SetBufferTextureStorage(stage, hostTexture, bufferCache, texture.Range, bindingInfo, false);
 
                     // Cache is not used for buffer texture, it must always rebind.
@@ -660,7 +660,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                     // Buffers are frequently re-created to accommodate larger data, so we need to re-bind
                     // to ensure we're not using a old buffer that was already deleted.
 
-                    var bufferCache = _channel.MemoryManager.GetBackingMemory(descriptor.UnpackAddress()).BufferCache;
+                    BufferCache bufferCache = _channel.MemoryManager.GetBackingMemory(descriptor.UnpackAddress()).BufferCache;
                     _channel.BufferManager.SetBufferTextureStorage(stage, hostTexture, bufferCache, texture.Range, bindingInfo, true);
 
                     // Cache is not used for buffer texture, it must always rebind.
@@ -717,7 +717,7 @@ namespace Ryujinx.Graphics.Gpu.Image
             int packedId = ReadPackedId(stageIndex, handle, textureBufferIndex, samplerBufferIndex);
             int textureId = TextureHandle.UnpackTextureId(packedId);
 
-            var physical = _channel.MemoryManager.GetBackingMemory(poolGpuVa);
+            PhysicalMemory physical = _channel.MemoryManager.GetBackingMemory(poolGpuVa);
             ulong poolAddress = _channel.MemoryManager.Translate(poolGpuVa);
 
             TexturePool texturePool = _texturePoolCache.FindOrCreate(_channel, physical, poolAddress, maximumId, _bindingsArrayCache);
@@ -754,7 +754,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         {
             (int textureWordOffset, int samplerWordOffset, TextureHandleType handleType) = TextureHandle.UnpackOffsets(wordOffset);
 
-            (var texturePhysicalMemory, ulong textureBufferAddress) = _isCompute
+            (PhysicalMemory texturePhysicalMemory, ulong textureBufferAddress) = _isCompute
                 ? _channel.BufferManager.GetComputeUniformBufferAddress(textureBufferIndex)
                 : _channel.BufferManager.GetGraphicsUniformBufferAddress(stageIndex, textureBufferIndex);
 
@@ -774,7 +774,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                 if (handleType != TextureHandleType.SeparateConstantSamplerHandle)
                 {
-                    (var samplerPhysicalMemory, ulong samplerBufferAddress) = _isCompute
+                    (PhysicalMemory samplerPhysicalMemory, ulong samplerBufferAddress) = _isCompute
                         ? _channel.BufferManager.GetComputeUniformBufferAddress(samplerBufferIndex)
                         : _channel.BufferManager.GetGraphicsUniformBufferAddress(stageIndex, samplerBufferIndex);
 
@@ -816,7 +816,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                 if (poolAddress != MemoryManager.PteUnmapped)
                 {
-                    var physical = _channel.MemoryManager.GetBackingMemory(_texturePoolGpuVa);
+                    PhysicalMemory physical = _channel.MemoryManager.GetBackingMemory(_texturePoolGpuVa);
                     texturePool = _texturePoolCache.FindOrCreate(_channel, physical, poolAddress, _texturePoolMaximumId, _bindingsArrayCache);
                     _texturePool = texturePool;
                 }
@@ -828,7 +828,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                 if (poolAddress != MemoryManager.PteUnmapped)
                 {
-                    var physical = _channel.MemoryManager.GetBackingMemory(_samplerPoolGpuVa);
+                    PhysicalMemory physical = _channel.MemoryManager.GetBackingMemory(_samplerPoolGpuVa);
                     samplerPool = _samplerPoolCache.FindOrCreate(_channel, physical, poolAddress, _samplerPoolMaximumId, _bindingsArrayCache);
                     _samplerPool = samplerPool;
                 }

--- a/src/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -385,8 +385,9 @@ namespace Ryujinx.Graphics.Gpu.Image
         public TexturePool GetTexturePool(ulong poolGpuVa, int maximumId)
         {
             ulong poolAddress = _channel.MemoryManager.Translate(poolGpuVa);
+            var physical = _channel.MemoryManager.GetBackingMemory(poolAddress);
 
-            TexturePool texturePool = _texturePoolCache.FindOrCreate(_channel, poolAddress, maximumId, _bindingsArrayCache);
+            TexturePool texturePool = _texturePoolCache.FindOrCreate(_channel, physical, poolAddress, maximumId, _bindingsArrayCache);
 
             return texturePool;
         }

--- a/src/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -1,5 +1,6 @@
 using Ryujinx.Graphics.GAL;
 using Ryujinx.Graphics.Gpu.Engine.Types;
+using Ryujinx.Graphics.Gpu.Memory;
 using Ryujinx.Graphics.Gpu.Shader;
 using System;
 
@@ -385,7 +386,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         public TexturePool GetTexturePool(ulong poolGpuVa, int maximumId)
         {
             ulong poolAddress = _channel.MemoryManager.Translate(poolGpuVa);
-            var physical = _channel.MemoryManager.GetBackingMemory(poolAddress);
+            PhysicalMemory physical = _channel.MemoryManager.GetBackingMemory(poolAddress);
 
             TexturePool texturePool = _texturePoolCache.FindOrCreate(_channel, physical, poolAddress, maximumId, _bindingsArrayCache);
 

--- a/src/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
@@ -160,9 +160,10 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// </summary>
         /// <param name="context">GPU context that the texture pool belongs to</param>
         /// <param name="channel">GPU channel that the texture pool belongs to</param>
+        /// <param name="physicalMemory">Backing memory of the pool</param>
         /// <param name="address">Address of the texture pool in guest memory</param>
         /// <param name="maximumId">Maximum texture ID of the texture pool (equal to maximum textures minus one)</param>
-        public TexturePool(GpuContext context, GpuChannel channel, ulong address, int maximumId) : base(context, channel.MemoryManager.Physical, address, maximumId)
+        public TexturePool(GpuContext context, GpuChannel channel, PhysicalMemory physicalMemory, ulong address, int maximumId) : base(context, physicalMemory, address, maximumId)
         {
             _channel = channel;
             _aliasLists = new Dictionary<Texture, TextureAliasList>();
@@ -192,8 +193,10 @@ namespace Ryujinx.Graphics.Gpu.Image
                         return ref descriptor;
                     }
 
-                    TextureInfo info = GetInfo(descriptor, out int layerSize);
-                    texture = PhysicalMemory.TextureCache.FindOrCreateTexture(_channel.MemoryManager, TextureSearchFlags.ForSampler, info, layerSize);
+                    var info = GetInfo(descriptor, out int layerSize);
+                    var memoryManager = _channel.MemoryManager;
+                    var textureCache = memoryManager.GetBackingMemory(descriptor.UnpackAddress()).TextureCache;
+                    texture = textureCache.FindOrCreateTexture(memoryManager, TextureSearchFlags.ForSampler, info, layerSize);
 
                     // If this happens, then the texture address is invalid, we can't add it to the cache.
                     if (texture == null)
@@ -361,7 +364,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="deferred">If true, queue the dereference to happen on the render thread, otherwise dereference immediately</param>
         public void ForceRemove(Texture texture, int id, bool deferred)
         {
-            Texture previous = Interlocked.Exchange(ref Items[id], null);
+            Texture  previous = Interlocked.Exchange(ref Items[id], null);
 
             if (deferred)
             {
@@ -421,7 +424,8 @@ namespace Ryujinx.Graphics.Gpu.Image
                         continue;
                     }
 
-                    MultiRange range = _channel.MemoryManager.Physical.TextureCache.UpdatePartiallyMapped(_channel.MemoryManager, address, texture);
+                    var textureCache = _channel.MemoryManager.GetBackingMemory(address).TextureCache;
+                    var range = textureCache.UpdatePartiallyMapped(_channel.MemoryManager, address, texture);
 
                     // If the texture is not mapped at all, delete its reference.
 
@@ -446,7 +450,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                     if (!range.Equals(texture.Range))
                     {
                         // Part of the texture was mapped or unmapped. Replace the range and regenerate tracking handles.
-                        if (!_channel.MemoryManager.Physical.TextureCache.UpdateMapping(texture, range))
+                        if (!textureCache.UpdateMapping(texture, range))
                         {
                             // Texture could not be remapped due to a collision, just delete it.
                             if (Interlocked.Exchange(ref Items[request.ID], null) != null)
@@ -481,6 +485,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="size">Size of the range being invalidated</param>
         protected override void InvalidateRangeImpl(ulong address, ulong size)
         {
+            var memoryManager = _channel.MemoryManager;
             ProcessDereferenceQueue();
 
             ulong endAddress = address + size;
@@ -505,7 +510,8 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                     if (texture.HasOneReference())
                     {
-                        _channel.MemoryManager.Physical.TextureCache.AddShortCache(texture, ref cachedDescriptor);
+                        var textureCache = memoryManager.GetBackingMemory(descriptor.UnpackAddress()).TextureCache;
+                        textureCache.AddShortCache(texture, ref cachedDescriptor);
                     }
 
                     if (Interlocked.Exchange(ref Items[id], null) != null)

--- a/src/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
@@ -193,9 +193,9 @@ namespace Ryujinx.Graphics.Gpu.Image
                         return ref descriptor;
                     }
 
-                    var info = GetInfo(descriptor, out int layerSize);
-                    var memoryManager = _channel.MemoryManager;
-                    var textureCache = memoryManager.GetBackingMemory(descriptor.UnpackAddress()).TextureCache;
+                    TextureInfo info = GetInfo(descriptor, out int layerSize);
+                    MemoryManager memoryManager = _channel.MemoryManager;
+                    TextureCache textureCache = memoryManager.GetBackingMemory(descriptor.UnpackAddress()).TextureCache;
                     texture = textureCache.FindOrCreateTexture(memoryManager, TextureSearchFlags.ForSampler, info, layerSize);
 
                     // If this happens, then the texture address is invalid, we can't add it to the cache.
@@ -364,7 +364,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="deferred">If true, queue the dereference to happen on the render thread, otherwise dereference immediately</param>
         public void ForceRemove(Texture texture, int id, bool deferred)
         {
-            Texture  previous = Interlocked.Exchange(ref Items[id], null);
+            Texture previous = Interlocked.Exchange(ref Items[id], null);
 
             if (deferred)
             {
@@ -424,8 +424,8 @@ namespace Ryujinx.Graphics.Gpu.Image
                         continue;
                     }
 
-                    var textureCache = _channel.MemoryManager.GetBackingMemory(address).TextureCache;
-                    var range = textureCache.UpdatePartiallyMapped(_channel.MemoryManager, address, texture);
+                    TextureCache textureCache = _channel.MemoryManager.GetBackingMemory(address).TextureCache;
+                    MultiRange range = textureCache.UpdatePartiallyMapped(_channel.MemoryManager, address, texture);
 
                     // If the texture is not mapped at all, delete its reference.
 
@@ -485,7 +485,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="size">Size of the range being invalidated</param>
         protected override void InvalidateRangeImpl(ulong address, ulong size)
         {
-            var memoryManager = _channel.MemoryManager;
+            MemoryManager memoryManager = _channel.MemoryManager;
             ProcessDereferenceQueue();
 
             ulong endAddress = address + size;
@@ -510,7 +510,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                     if (texture.HasOneReference())
                     {
-                        var textureCache = memoryManager.GetBackingMemory(descriptor.UnpackAddress()).TextureCache;
+                        TextureCache textureCache = memoryManager.GetBackingMemory(descriptor.UnpackAddress()).TextureCache;
                         textureCache.AddShortCache(texture, ref cachedDescriptor);
                     }
 

--- a/src/Ryujinx.Graphics.Gpu/Image/TexturePoolCache.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TexturePoolCache.cs
@@ -1,3 +1,5 @@
+using Ryujinx.Graphics.Gpu.Memory;
+
 namespace Ryujinx.Graphics.Gpu.Image
 {
     /// <summary>
@@ -20,11 +22,17 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// </summary>
         /// <param name="context">GPU context that the texture pool belongs to</param>
         /// <param name="channel">GPU channel that the texture pool belongs to</param>
+        /// <param name="physicalMemory">Backing memory of the pool</param>
         /// <param name="address">Address of the texture pool in guest memory</param>
         /// <param name="maximumId">Maximum texture ID of the texture pool (equal to maximum textures minus one)</param>
-        protected override TexturePool CreatePool(GpuContext context, GpuChannel channel, ulong address, int maximumId)
+        protected override TexturePool CreatePool(
+            GpuContext context,
+            GpuChannel channel,
+            PhysicalMemory physicalMemory,
+            ulong address,
+            int maximumId)
         {
-            return new TexturePool(context, channel, address, maximumId);
+            return new TexturePool(context, channel, physicalMemory, address, maximumId);
         }
     }
 }

--- a/src/Ryujinx.Graphics.Gpu/Memory/BufferBounds.cs
+++ b/src/Ryujinx.Graphics.Gpu/Memory/BufferBounds.cs
@@ -10,6 +10,16 @@ namespace Ryujinx.Graphics.Gpu.Memory
     readonly struct BufferBounds : IEquatable<BufferBounds>
     {
         /// <summary>
+        /// Physical memory backing the buffer.
+        /// </summary>
+        public PhysicalMemory Physical { get; }
+
+        /// <summary>
+        /// Buffer cache that owns the buffer.
+        /// </summary>
+        public BufferCache BufferCache => Physical.BufferCache;
+
+        /// <summary>
         /// Physical memory ranges where the buffer is mapped.
         /// </summary>
         public MultiRange Range { get; }
@@ -29,8 +39,9 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// </summary>
         /// <param name="range">Physical memory ranges where the buffer is mapped</param>
         /// <param name="flags">Buffer usage flags</param>
-        public BufferBounds(MultiRange range, BufferUsageFlags flags = BufferUsageFlags.None)
+        public BufferBounds(PhysicalMemory physical, MultiRange range, BufferUsageFlags flags = BufferUsageFlags.None)
         {
+            Physical = physical;
             Range = range;
             Flags = flags;
         }

--- a/src/Ryujinx.Graphics.Gpu/Memory/BufferCache.cs
+++ b/src/Ryujinx.Graphics.Gpu/Memory/BufferCache.cs
@@ -742,11 +742,11 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// <param name="size">Size in bytes of the copy</param>
         public static void CopyBuffer(GpuContext context, MemoryManager memoryManager, ulong srcVa, ulong dstVa, ulong size)
         {
-            var srcPhysical = memoryManager.GetBackingMemory(srcVa);
-            var dstPhysical = memoryManager.GetBackingMemory(dstVa);
+            PhysicalMemory srcPhysical = memoryManager.GetBackingMemory(srcVa);
+            PhysicalMemory dstPhysical = memoryManager.GetBackingMemory(dstVa);
 
-            var srcRange = srcPhysical.BufferCache.TranslateAndCreateBuffer(memoryManager, srcVa, size, BufferStage.Copy);
-            var dstRange = dstPhysical.BufferCache.TranslateAndCreateBuffer(memoryManager, dstVa, size, BufferStage.Copy);
+            MultiRange srcRange = srcPhysical.BufferCache.TranslateAndCreateBuffer(memoryManager, srcVa, size, BufferStage.Copy);
+            MultiRange dstRange = dstPhysical.BufferCache.TranslateAndCreateBuffer(memoryManager, dstVa, size, BufferStage.Copy);
 
             if (srcRange.Count == 1 && dstRange.Count == 1)
             {
@@ -810,8 +810,8 @@ namespace Ryujinx.Graphics.Gpu.Memory
             ulong dstAddress,
             ulong size)
         {
-            var srcBuffer = srcPhysical.BufferCache.GetBuffer(srcAddress, size, BufferStage.Copy);
-            var dstBuffer = dstPhysical.BufferCache.GetBuffer(dstAddress, size, BufferStage.Copy);
+            Buffer srcBuffer = srcPhysical.BufferCache.GetBuffer(srcAddress, size, BufferStage.Copy);
+            Buffer dstBuffer = dstPhysical.BufferCache.GetBuffer(dstAddress, size, BufferStage.Copy);
 
             int srcOffset = (int)(srcAddress - srcBuffer.Address);
             int dstOffset = (int)(dstAddress - dstBuffer.Address);

--- a/src/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
+++ b/src/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
@@ -66,18 +66,19 @@ namespace Ryujinx.Graphics.Gpu.Memory
                 Buffers = new BufferBounds[count];
                 Unaligned = new bool[count];
 
-                Buffers.AsSpan().Fill(new BufferBounds(new MultiRange(MemoryManager.PteUnmapped, 0UL)));
+                Buffers.AsSpan().Fill(new BufferBounds(null, new MultiRange(MemoryManager.PteUnmapped, 0UL)));
             }
 
             /// <summary>
             /// Sets the region of a buffer at a given slot.
             /// </summary>
             /// <param name="index">Buffer slot</param>
+            /// <param name="physical">Physical memory backing the buffer</param>
             /// <param name="range">Physical memory regions where the buffer is mapped</param>
             /// <param name="flags">Buffer usage flags</param>
-            public void SetBounds(int index, MultiRange range, BufferUsageFlags flags = BufferUsageFlags.None)
+            public void SetBounds(int index, PhysicalMemory physical, MultiRange range, BufferUsageFlags flags = BufferUsageFlags.None)
             {
-                Buffers[index] = new BufferBounds(range, flags);
+                Buffers[index] = new BufferBounds(physical, range, flags);
             }
 
             /// <summary>
@@ -156,8 +157,10 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// <param name="type">Type of each index buffer element</param>
         public void SetIndexBuffer(ulong gpuVa, ulong size, IndexType type)
         {
-            MultiRange range = _channel.MemoryManager.Physical.BufferCache.TranslateAndCreateBuffer(_channel.MemoryManager, gpuVa, size, BufferStage.IndexBuffer);
+            var bufferCache = _channel.MemoryManager.GetBackingMemory(gpuVa).BufferCache;
+            MultiRange range = bufferCache.TranslateAndCreateBuffer(_channel.MemoryManager, gpuVa, size, BufferStage.IndexBuffer);
 
+            _indexBuffer.BufferCache = bufferCache;
             _indexBuffer.Range = range;
             _indexBuffer.Type = type;
 
@@ -186,11 +189,15 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// <param name="divisor">Vertex divisor of the buffer, for instanced draws</param>
         public void SetVertexBuffer(int index, ulong gpuVa, ulong size, int stride, int divisor)
         {
-            MultiRange range = _channel.MemoryManager.Physical.BufferCache.TranslateAndCreateBuffer(_channel.MemoryManager, gpuVa, size, BufferStage.VertexBuffer);
+            var bufferCache = _channel.MemoryManager.GetBackingMemory(gpuVa).BufferCache;
+            MultiRange range = bufferCache.TranslateAndCreateBuffer(_channel.MemoryManager, gpuVa, size, BufferStage.VertexBuffer);
 
-            _vertexBuffers[index].Range = range;
-            _vertexBuffers[index].Stride = stride;
-            _vertexBuffers[index].Divisor = divisor;
+            ref VertexBuffer vb = ref _vertexBuffers[index];
+
+            vb.BufferCache = bufferCache;
+            vb.Range = range;
+            vb.Stride = stride;
+            vb.Divisor = divisor;
 
             _vertexBuffersDirty = true;
 
@@ -213,9 +220,10 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// <param name="size">Size in bytes of the transform feedback buffer</param>
         public void SetTransformFeedbackBuffer(int index, ulong gpuVa, ulong size)
         {
-            MultiRange range = _channel.MemoryManager.Physical.BufferCache.TranslateAndCreateMultiBuffers(_channel.MemoryManager, gpuVa, size, BufferStage.TransformFeedback);
+            var physical = _channel.MemoryManager.GetBackingMemory(gpuVa);
+            var range = physical.BufferCache.TranslateAndCreateMultiBuffers(_channel.MemoryManager, gpuVa, size, BufferStage.TransformFeedback);
 
-            _transformFeedbackBuffers[index] = new BufferBounds(range);
+            _transformFeedbackBuffers[index] = new BufferBounds(physical, range);
             _transformFeedbackBuffersDirty = true;
         }
 
@@ -258,11 +266,12 @@ namespace Ryujinx.Graphics.Gpu.Memory
 
             RecordStorageAlignment(_cpStorageBuffers, index, gpuVa);
 
-            gpuVa = BitUtils.AlignDown<ulong>(gpuVa, (ulong)_context.Capabilities.StorageBufferOffsetAlignment);
+            gpuVa = BitUtils.AlignDown(gpuVa, (ulong)_context.Capabilities.StorageBufferOffsetAlignment);
 
-            MultiRange range = _channel.MemoryManager.Physical.BufferCache.TranslateAndCreateMultiBuffers(_channel.MemoryManager, gpuVa, size, BufferStageUtils.ComputeStorage(flags));
+            var physical = _channel.MemoryManager.GetBackingMemory(gpuVa);
+            var range = physical.BufferCache.TranslateAndCreateMultiBuffers(_channel.MemoryManager, gpuVa, size, BufferStageUtils.ComputeStorage(flags));
 
-            _cpStorageBuffers.SetBounds(index, range, flags);
+            _cpStorageBuffers.SetBounds(index, physical, range, flags);
         }
 
         /// <summary>
@@ -282,16 +291,17 @@ namespace Ryujinx.Graphics.Gpu.Memory
 
             RecordStorageAlignment(buffers, index, gpuVa);
 
-            gpuVa = BitUtils.AlignDown<ulong>(gpuVa, (ulong)_context.Capabilities.StorageBufferOffsetAlignment);
+            gpuVa = BitUtils.AlignDown(gpuVa, (ulong)_context.Capabilities.StorageBufferOffsetAlignment);
 
-            MultiRange range = _channel.MemoryManager.Physical.BufferCache.TranslateAndCreateMultiBuffers(_channel.MemoryManager, gpuVa, size, BufferStageUtils.GraphicsStorage(stage, flags));
+            var physical = _channel.MemoryManager.GetBackingMemory(gpuVa);
+            MultiRange range = physical.BufferCache.TranslateAndCreateMultiBuffers(_channel.MemoryManager, gpuVa, size, BufferStageUtils.GraphicsStorage(stage, flags));
 
             if (!buffers.Buffers[index].Range.Equals(range))
             {
                 _gpStorageBuffersDirty = true;
             }
 
-            buffers.SetBounds(index, range, flags);
+            buffers.SetBounds(index, physical, range, flags);
         }
 
         /// <summary>
@@ -303,9 +313,10 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// <param name="size">Size in bytes of the storage buffer</param>
         public void SetComputeUniformBuffer(int index, ulong gpuVa, ulong size)
         {
-            MultiRange range = _channel.MemoryManager.Physical.BufferCache.TranslateAndCreateBuffer(_channel.MemoryManager, gpuVa, size, BufferStage.Compute);
+            var physical = _channel.MemoryManager.GetBackingMemory(gpuVa);
+            MultiRange range = physical.BufferCache.TranslateAndCreateBuffer(_channel.MemoryManager, gpuVa, size, BufferStage.Compute);
 
-            _cpUniformBuffers.SetBounds(index, range);
+            _cpUniformBuffers.SetBounds(index, physical, range);
         }
 
         /// <summary>
@@ -318,9 +329,10 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// <param name="size">Size in bytes of the storage buffer</param>
         public void SetGraphicsUniformBuffer(int stage, int index, ulong gpuVa, ulong size)
         {
-            MultiRange range = _channel.MemoryManager.Physical.BufferCache.TranslateAndCreateBuffer(_channel.MemoryManager, gpuVa, size, BufferStageUtils.FromShaderStage(stage));
+            var physical = _channel.MemoryManager.GetBackingMemory(gpuVa);
+            MultiRange range = _channel.MemoryManager.GetBackingMemory(gpuVa).BufferCache.TranslateAndCreateBuffer(_channel.MemoryManager, gpuVa, size, BufferStageUtils.FromShaderStage(stage));
 
-            _gpUniformBuffers[stage].SetBounds(index, range);
+            _gpUniformBuffers[stage].SetBounds(index, physical, range);
             _gpUniformBuffersDirty = true;
         }
 
@@ -416,9 +428,10 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// </summary>
         /// <param name="index">Index of the uniform buffer binding</param>
         /// <returns>The uniform buffer address, or an undefined value if the buffer is not currently bound</returns>
-        public ulong GetComputeUniformBufferAddress(int index)
+        public (PhysicalMemory, ulong) GetComputeUniformBufferAddress(int index)
         {
-            return _cpUniformBuffers.Buffers[index].Range.GetSubRange(0).Address;
+            ref var buffer = ref _cpUniformBuffers.Buffers[index];
+            return (buffer.Physical, buffer.Range.GetSubRange(0).Address);
         }
 
         /// <summary>
@@ -437,9 +450,10 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// <param name="stage">Index of the shader stage</param>
         /// <param name="index">Index of the uniform buffer binding</param>
         /// <returns>The uniform buffer address, or an undefined value if the buffer is not currently bound</returns>
-        public ulong GetGraphicsUniformBufferAddress(int stage, int index)
+        public (PhysicalMemory, ulong) GetGraphicsUniformBufferAddress(int stage, int index)
         {
-            return _gpUniformBuffers[stage].Buffers[index].Range.GetSubRange(0).Address;
+            ref var buffer = ref _gpUniformBuffers[stage].Buffers[index];
+            return (buffer.Physical, buffer.Range.GetSubRange(0).Address);
         }
 
         /// <summary>
@@ -478,12 +492,10 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// </summary>
         public void CommitComputeBindings()
         {
-            BufferCache bufferCache = _channel.MemoryManager.Physical.BufferCache;
+            BindBuffers(_cpStorageBuffers, isStorage: true);
+            BindBuffers(_cpUniformBuffers, isStorage: false);
 
-            BindBuffers(bufferCache, _cpStorageBuffers, isStorage: true);
-            BindBuffers(bufferCache, _cpUniformBuffers, isStorage: false);
-
-            CommitBufferTextureBindings(bufferCache);
+            CommitBufferTextureBindings();
 
             // Force rebind after doing compute work.
             Rebind();
@@ -495,14 +507,14 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// Commit any queued buffer texture bindings.
         /// </summary>
         /// <param name="bufferCache">Buffer cache</param>
-        private void CommitBufferTextureBindings(BufferCache bufferCache)
+        private void CommitBufferTextureBindings()
         {
             if (_bufferTextures.Count > 0)
             {
-                foreach (BufferTextureBinding binding in _bufferTextures)
+                foreach (var binding in _bufferTextures)
                 {
-                    bool isStore = binding.BindingInfo.Flags.HasFlag(TextureUsageFlags.ImageStore);
-                    BufferRange range = bufferCache.GetBufferRange(binding.Range, BufferStageUtils.TextureBuffer(binding.Stage, binding.BindingInfo.Flags), isStore);
+                    var isStore = binding.BindingInfo.Flags.HasFlag(TextureUsageFlags.ImageStore);
+                    var range = binding.BufferCache.GetBufferRange(binding.Range, BufferStageUtils.TextureBuffer(binding.Stage, binding.BindingInfo.Flags), isStore);
                     binding.Texture.SetStorage(range);
 
                     // The texture must be rebound to use the new storage if it was updated.
@@ -524,19 +536,19 @@ namespace Ryujinx.Graphics.Gpu.Memory
             {
                 ITexture[] textureArray = new ITexture[1];
 
-                foreach (BufferTextureArrayBinding<ITextureArray> binding in _bufferTextureArrays)
+                foreach (var binding in _bufferTextureArrays)
                 {
-                    BufferRange range = bufferCache.GetBufferRange(binding.Range, BufferStage.None);
+                    var range = binding.BufferCache.GetBufferRange(binding.Range, BufferStage.None);
                     binding.Texture.SetStorage(range);
 
                     textureArray[0] = binding.Texture;
                     binding.Array.SetTextures(binding.Index, textureArray);
                 }
 
-                foreach (BufferTextureArrayBinding<IImageArray> binding in _bufferImageArrays)
+                foreach (var binding in _bufferImageArrays)
                 {
-                    bool isStore = binding.BindingInfo.Flags.HasFlag(TextureUsageFlags.ImageStore);
-                    BufferRange range = bufferCache.GetBufferRange(binding.Range, BufferStage.None, isStore);
+                    var isStore = binding.BindingInfo.Flags.HasFlag(TextureUsageFlags.ImageStore);
+                    var range = binding.BufferCache.GetBufferRange(binding.Range, BufferStage.None, isStore);
                     binding.Texture.SetStorage(range);
 
                     textureArray[0] = binding.Texture;
@@ -555,8 +567,6 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// <param name="indexed">True if the index buffer is in use</param>
         public void CommitGraphicsBindings(bool indexed)
         {
-            BufferCache bufferCache = _channel.MemoryManager.Physical.BufferCache;
-
             if (indexed)
             {
                 if (_indexBufferDirty || _rebind)
@@ -565,14 +575,14 @@ namespace Ryujinx.Graphics.Gpu.Memory
 
                     if (!_indexBuffer.Range.IsUnmapped)
                     {
-                        BufferRange buffer = bufferCache.GetBufferRange(_indexBuffer.Range, BufferStage.IndexBuffer);
+                        BufferRange buffer = _indexBuffer.BufferCache.GetBufferRange(_indexBuffer.Range, BufferStage.IndexBuffer);
 
                         _context.Renderer.Pipeline.SetIndexBuffer(buffer, _indexBuffer.Type);
                     }
                 }
                 else if (!_indexBuffer.Range.IsUnmapped)
                 {
-                    bufferCache.SynchronizeBufferRange(_indexBuffer.Range);
+                    _indexBuffer.BufferCache.SynchronizeBufferRange(_indexBuffer.Range);
                 }
             }
             else if (_rebind)
@@ -597,7 +607,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
                         continue;
                     }
 
-                    BufferRange buffer = bufferCache.GetBufferRange(vb.Range, BufferStage.VertexBuffer);
+                    BufferRange buffer = vb.BufferCache.GetBufferRange(vb.Range, BufferStage.VertexBuffer);
 
                     vertexBuffers[index] = new VertexBufferDescriptor(buffer, vb.Stride, vb.Divisor);
                 }
@@ -615,7 +625,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
                         continue;
                     }
 
-                    bufferCache.SynchronizeBufferRange(vb.Range);
+                    vb.BufferCache.SynchronizeBufferRange(vb.Range);
                 }
             }
 
@@ -637,7 +647,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
                             continue;
                         }
 
-                        tfbs[index] = bufferCache.GetBufferRange(tfb.Range, BufferStage.TransformFeedback, write: true);
+                        tfbs[index] = tfb.BufferCache.GetBufferRange(tfb.Range, BufferStage.TransformFeedback, write: true);
                     }
 
                     _context.Renderer.Pipeline.SetTransformFeedbackBuffers(tfbs);
@@ -684,7 +694,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
 
                             _context.SupportBufferUpdater.SetTfeOffset(index, tfeOffset);
 
-                            buffers[index] = new BufferAssignment(index, bufferCache.GetBufferRange(range, BufferStage.TransformFeedback, write: true));
+                            buffers[index] = new BufferAssignment(index, tfb.BufferCache.GetBufferRange(range, BufferStage.TransformFeedback, write: true));
                         }
                     }
 
@@ -702,7 +712,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
                         continue;
                     }
 
-                    bufferCache.SynchronizeBufferRange(tfb.Range);
+                    tfb.BufferCache.SynchronizeBufferRange(tfb.Range);
                 }
             }
 
@@ -710,7 +720,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
             {
                 _gpStorageBuffersDirty = false;
 
-                BindBuffers(bufferCache, _gpStorageBuffers, isStorage: true);
+                BindBuffers(_gpStorageBuffers, isStorage: true);
             }
             else
             {
@@ -721,14 +731,14 @@ namespace Ryujinx.Graphics.Gpu.Memory
             {
                 _gpUniformBuffersDirty = false;
 
-                BindBuffers(bufferCache, _gpUniformBuffers, isStorage: false);
+                BindBuffers(_gpUniformBuffers, isStorage: false);
             }
             else
             {
                 UpdateBuffers(_gpUniformBuffers);
             }
 
-            CommitBufferTextureBindings(bufferCache);
+            CommitBufferTextureBindings();
 
             _rebind = false;
 
@@ -742,7 +752,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// <param name="bindings">Buffer memory ranges to bind</param>
         /// <param name="isStorage">True to bind as storage buffer, false to bind as uniform buffer</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void BindBuffers(BufferCache bufferCache, BuffersPerStage[] bindings, bool isStorage)
+        private void BindBuffers(BuffersPerStage[] bindings, bool isStorage)
         {
             int rangesCount = 0;
 
@@ -750,21 +760,21 @@ namespace Ryujinx.Graphics.Gpu.Memory
 
             for (ShaderStage stage = ShaderStage.Vertex; stage <= ShaderStage.Fragment; stage++)
             {
-                ref BuffersPerStage buffers = ref bindings[(int)stage - 1];
+                ref var buffers = ref bindings[(int)stage - 1];
                 BufferStage bufferStage = BufferStageUtils.FromShaderStage(stage);
 
                 for (int index = 0; index < buffers.Count; index++)
                 {
-                    ref BufferDescriptor bindingInfo = ref buffers.Bindings[index];
+                    ref var bindingInfo = ref buffers.Bindings[index];
 
                     BufferBounds bounds = buffers.Buffers[bindingInfo.Slot];
 
                     if (!bounds.IsUnmapped)
                     {
-                        bool isWrite = bounds.Flags.HasFlag(BufferUsageFlags.Write);
-                        BufferRange range = isStorage
-                            ? bufferCache.GetBufferRangeAligned(bounds.Range, bufferStage | BufferStageUtils.FromUsage(bounds.Flags), isWrite)
-                            : bufferCache.GetBufferRange(bounds.Range, bufferStage);
+                        var isWrite = bounds.Flags.HasFlag(BufferUsageFlags.Write);
+                        var range = isStorage
+                            ? bounds.BufferCache.GetBufferRangeAligned(bounds.Range, bufferStage | BufferStageUtils.FromUsage(bounds.Flags), isWrite)
+                            : bounds.BufferCache.GetBufferRange(bounds.Range, bufferStage);
 
                         ranges[rangesCount++] = new BufferAssignment(bindingInfo.Binding, range);
                     }
@@ -780,11 +790,10 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// <summary>
         /// Bind respective buffer bindings on the host API.
         /// </summary>
-        /// <param name="bufferCache">Buffer cache holding the buffers for the specified ranges</param>
         /// <param name="buffers">Buffer memory ranges to bind</param>
         /// <param name="isStorage">True to bind as storage buffer, false to bind as uniform buffer</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void BindBuffers(BufferCache bufferCache, BuffersPerStage buffers, bool isStorage)
+        private void BindBuffers(BuffersPerStage buffers, bool isStorage)
         {
             int rangesCount = 0;
 
@@ -792,16 +801,16 @@ namespace Ryujinx.Graphics.Gpu.Memory
 
             for (int index = 0; index < buffers.Count; index++)
             {
-                ref BufferDescriptor bindingInfo = ref buffers.Bindings[index];
+                ref var bindingInfo = ref buffers.Bindings[index];
 
                 BufferBounds bounds = buffers.Buffers[bindingInfo.Slot];
 
                 if (!bounds.IsUnmapped)
                 {
-                    bool isWrite = bounds.Flags.HasFlag(BufferUsageFlags.Write);
-                    BufferRange range = isStorage
-                        ? bufferCache.GetBufferRangeAligned(bounds.Range, BufferStageUtils.ComputeStorage(bounds.Flags), isWrite)
-                        : bufferCache.GetBufferRange(bounds.Range, BufferStage.Compute);
+                    var isWrite = bounds.Flags.HasFlag(BufferUsageFlags.Write);
+                    var range = isStorage
+                        ? bounds.BufferCache.GetBufferRangeAligned(bounds.Range, BufferStageUtils.ComputeStorage(bounds.Flags), isWrite)
+                        : bounds.BufferCache.GetBufferRange(bounds.Range, BufferStage.Compute);
 
                     ranges[rangesCount++] = new BufferAssignment(bindingInfo.Binding, range);
                 }
@@ -841,11 +850,11 @@ namespace Ryujinx.Graphics.Gpu.Memory
         {
             for (ShaderStage stage = ShaderStage.Vertex; stage <= ShaderStage.Fragment; stage++)
             {
-                ref BuffersPerStage buffers = ref bindings[(int)stage - 1];
+                ref var buffers = ref bindings[(int)stage - 1];
 
                 for (int index = 0; index < buffers.Count; index++)
                 {
-                    ref BufferDescriptor binding = ref buffers.Bindings[index];
+                    ref var binding = ref buffers.Bindings[index];
 
                     BufferBounds bounds = buffers.Buffers[binding.Slot];
 
@@ -854,7 +863,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
                         continue;
                     }
 
-                    _channel.MemoryManager.Physical.BufferCache.SynchronizeBufferRange(bounds.Range);
+                    bounds.BufferCache.SynchronizeBufferRange(bounds.Range);
                 }
             }
         }
@@ -871,13 +880,14 @@ namespace Ryujinx.Graphics.Gpu.Memory
         public void SetBufferTextureStorage(
             ShaderStage stage,
             ITexture texture,
+            BufferCache bufferCache,
             MultiRange range,
             TextureBindingInfo bindingInfo,
             bool isImage)
         {
-            _channel.MemoryManager.Physical.BufferCache.CreateBuffer(range, BufferStageUtils.TextureBuffer(stage, bindingInfo.Flags));
+            bufferCache.CreateBuffer(range, BufferStageUtils.TextureBuffer(stage, bindingInfo.Flags));
 
-            _bufferTextures.Add(new BufferTextureBinding(stage, texture, range, bindingInfo, isImage));
+            _bufferTextures.Add(new BufferTextureBinding(stage, texture, bufferCache, range, bindingInfo, isImage));
         }
 
         /// <summary>
@@ -894,13 +904,14 @@ namespace Ryujinx.Graphics.Gpu.Memory
             ShaderStage stage,
             ITextureArray array,
             ITexture texture,
+            BufferCache bufferCache,
             MultiRange range,
             TextureBindingInfo bindingInfo,
             int index)
         {
-            _channel.MemoryManager.Physical.BufferCache.CreateBuffer(range, BufferStageUtils.TextureBuffer(stage, bindingInfo.Flags));
+            bufferCache.CreateBuffer(range, BufferStageUtils.TextureBuffer(stage, bindingInfo.Flags));
 
-            _bufferTextureArrays.Add(new BufferTextureArrayBinding<ITextureArray>(array, texture, range, bindingInfo, index));
+            _bufferTextureArrays.Add(new BufferTextureArrayBinding<ITextureArray>(array, texture, bufferCache, range, bindingInfo, index));
         }
 
         /// <summary>
@@ -917,13 +928,14 @@ namespace Ryujinx.Graphics.Gpu.Memory
             ShaderStage stage,
             IImageArray array,
             ITexture texture,
+            BufferCache bufferCache,
             MultiRange range,
             TextureBindingInfo bindingInfo,
             int index)
         {
-            _channel.MemoryManager.Physical.BufferCache.CreateBuffer(range, BufferStageUtils.TextureBuffer(stage, bindingInfo.Flags));
+            bufferCache.CreateBuffer(range, BufferStageUtils.TextureBuffer(stage, bindingInfo.Flags));
 
-            _bufferImageArrays.Add(new BufferTextureArrayBinding<IImageArray>(array, texture, range, bindingInfo, index));
+            _bufferImageArrays.Add(new BufferTextureArrayBinding<IImageArray>(array, texture, bufferCache, range, bindingInfo, index));
         }
 
         /// <summary>

--- a/src/Ryujinx.Graphics.Gpu/Memory/BufferTextureArrayBinding.cs
+++ b/src/Ryujinx.Graphics.Gpu/Memory/BufferTextureArrayBinding.cs
@@ -20,6 +20,11 @@ namespace Ryujinx.Graphics.Gpu.Memory
         public ITexture Texture { get; }
 
         /// <summary>
+        /// Buffer cache that owns the buffer.
+        /// </summary>
+        public BufferCache BufferCache { get; }
+
+        /// <summary>
         /// Physical ranges of memory where the buffer texture data is located.
         /// </summary>
         public MultiRange Range { get; }
@@ -39,18 +44,21 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// </summary>
         /// <param name="array">Array</param>
         /// <param name="texture">Buffer texture</param>
+        /// <param name="bufferCache">Buffer cache that owns the buffer</param>
         /// <param name="range">Physical ranges of memory where the buffer texture data is located</param>
         /// <param name="bindingInfo">Binding info</param>
         /// <param name="index">Index of the binding on the array</param>
         public BufferTextureArrayBinding(
             T array,
             ITexture texture,
+            BufferCache bufferCache,
             MultiRange range,
             TextureBindingInfo bindingInfo,
             int index)
         {
             Array = array;
             Texture = texture;
+            BufferCache = bufferCache;
             Range = range;
             BindingInfo = bindingInfo;
             Index = index;

--- a/src/Ryujinx.Graphics.Gpu/Memory/BufferTextureBinding.cs
+++ b/src/Ryujinx.Graphics.Gpu/Memory/BufferTextureBinding.cs
@@ -21,6 +21,11 @@ namespace Ryujinx.Graphics.Gpu.Memory
         public ITexture Texture { get; }
 
         /// <summary>
+        /// Buffer cache that owns the buffer.
+        /// </summary>
+        public BufferCache BufferCache { get; }
+
+        /// <summary>
         /// Physical ranges of memory where the buffer texture data is located.
         /// </summary>
         public MultiRange Range { get; }
@@ -40,18 +45,21 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// </summary>
         /// <param name="stage">Shader stage accessing the texture</param>
         /// <param name="texture">Buffer texture</param>
+        /// <param name="bufferCache">Buffer cache that owns the buffer</param>
         /// <param name="range">Physical ranges of memory where the buffer texture data is located</param>
         /// <param name="bindingInfo">Binding info</param>
         /// <param name="isImage">Whether the binding is for an image or a sampler</param>
         public BufferTextureBinding(
             ShaderStage stage,
             ITexture texture,
+            BufferCache bufferCache,
             MultiRange range,
             TextureBindingInfo bindingInfo,
             bool isImage)
         {
             Stage = stage;
             Texture = texture;
+            BufferCache = bufferCache;
             Range = range;
             BindingInfo = bindingInfo;
             IsImage = isImage;

--- a/src/Ryujinx.Graphics.Gpu/Memory/IndexBuffer.cs
+++ b/src/Ryujinx.Graphics.Gpu/Memory/IndexBuffer.cs
@@ -8,6 +8,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
     /// </summary>
     struct IndexBuffer
     {
+        public BufferCache BufferCache;
         public MultiRange Range;
         public IndexType Type;
     }

--- a/src/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
+++ b/src/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
@@ -1,4 +1,5 @@
 using Ryujinx.Common.Memory;
+using Ryujinx.Graphics.Gpu.Image;
 using Ryujinx.Memory;
 using Ryujinx.Memory.Range;
 using System;
@@ -35,10 +36,9 @@ namespace Ryujinx.Graphics.Gpu.Memory
 
         public event EventHandler<UnmapEventArgs> MemoryUnmapped;
 
-        /// <summary>
-        /// Physical memory where the virtual memory is mapped into.
-        /// </summary>
-        internal PhysicalMemory Physical { get; }
+        private readonly GpuContext _context;
+        private readonly List<PhysicalMemory> _physicalMemoryList;
+        private readonly Dictionary<PhysicalMemory, byte> _physicalMemoryMap;
 
         /// <summary>
         /// Virtual range cache.
@@ -53,19 +53,65 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// <summary>
         /// Creates a new instance of the GPU memory manager.
         /// </summary>
+        /// <param name="context">GPU context</param>
         /// <param name="physicalMemory">Physical memory that this memory manager will map into</param>
         /// <param name="cpuMemorySize">The amount of physical CPU Memory Avaiable on the device.</param>
-        internal MemoryManager(PhysicalMemory physicalMemory, ulong cpuMemorySize)
+
+        internal MemoryManager(GpuContext context, PhysicalMemory physicalMemory, ulong cpuMemorySize)
         {
-            Physical = physicalMemory;
+            _context = context;
+
+            _physicalMemoryList = new List<PhysicalMemory>()
+            {
+                physicalMemory
+            };
+
+            _physicalMemoryMap = new Dictionary<PhysicalMemory, byte>
+            {
+                { physicalMemory, 0 }
+            };
+
             VirtualRangeCache = new VirtualRangeCache(this);
             CounterCache = new CounterCache();
             _pageTable = new ulong[PtLvl0Size][];
-            MemoryUnmapped += Physical.TextureCache.MemoryUnmappedHandler;
-            MemoryUnmapped += Physical.BufferCache.MemoryUnmappedHandler;
+            MemoryUnmapped += physicalMemory.TextureCache.MemoryUnmappedHandler;
+            MemoryUnmapped += physicalMemory.BufferCache.MemoryUnmappedHandler;
             MemoryUnmapped += VirtualRangeCache.MemoryUnmappedHandler;
             MemoryUnmapped += CounterCache.MemoryUnmappedHandler;
-            Physical.TextureCache.Initialize(cpuMemorySize);
+            physicalMemory.TextureCache.Initialize(cpuMemorySize);
+        }
+
+        /// <summary>
+        /// Attaches the memory manager to a new GPU channel.
+        /// </summary>
+        /// <param name="rebind">Action to be performed when the buffer cache changes</param>
+        internal void AttachToChannel(Action rebind)
+        {
+            PhysicalMemory physicalMemory = GetOwnPhysicalMemory();
+
+            physicalMemory.IncrementReferenceCount();
+            physicalMemory.BufferCache.NotifyBuffersModified += rebind;
+            physicalMemory.BufferCache.QueuePrune();
+        }
+
+        /// <summary>
+        /// Attaches the memory manager to a new GPU channel.
+        /// </summary>
+        /// <param name="rebind">Action that was performed when the buffer cache changed</param>
+        internal void DetachFromChannel(Action rebind)
+        {
+            PhysicalMemory physicalMemory = GetOwnPhysicalMemory();
+
+            physicalMemory.BufferCache.NotifyBuffersModified -= rebind;
+            physicalMemory.DecrementReferenceCount();
+        }
+
+        /// <summary>
+        /// Queues a prune of invalid entries on the buffer cache.
+        /// </summary>
+        internal void QueuePrune()
+        {
+            GetOwnPhysicalMemory().BufferCache.QueuePrune();
         }
 
         /// <summary>
@@ -81,15 +127,15 @@ namespace Ryujinx.Graphics.Gpu.Memory
 
             if (IsContiguous(va, size))
             {
-                ulong address = Translate(va);
+                (PhysicalMemory physicalMemory, ulong address) = TranslateWithPhysicalMemory(va);
 
                 if (tracked)
                 {
-                    return Physical.ReadTracked<T>(address);
+                    return physicalMemory.ReadTracked<T>(address);
                 }
                 else
                 {
-                    return Physical.Read<T>(address);
+                    return physicalMemory.Read<T>(address);
                 }
             }
             else
@@ -113,7 +159,9 @@ namespace Ryujinx.Graphics.Gpu.Memory
         {
             if (IsContiguous(va, size))
             {
-                return Physical.GetSpan(Translate(va), size, tracked);
+                (PhysicalMemory physicalMemory, ulong address) = TranslateWithPhysicalMemory(va);
+
+                return physicalMemory.GetSpan(address, size, tracked);
             }
             else
             {
@@ -138,7 +186,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
             bool isContiguous = true;
             int mappedSize;
 
-            if (ValidateAddress(va) && GetPte(va) != PteUnmapped && Physical.IsMapped(Translate(va)))
+            if (ValidateAddress(va) && IsMappedOnGpuAndPhysical(va))
             {
                 ulong endVa = va + (ulong)size;
                 ulong endVaAligned = (endVa + PageMask) & ~PageMask;
@@ -151,7 +199,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
                     ulong nextVa = currentVa + PageSize;
                     ulong nextPa = Translate(nextVa);
 
-                    if (!ValidateAddress(nextVa) || GetPte(nextVa) == PteUnmapped || !Physical.IsMapped(nextPa))
+                    if (!ValidateAddress(nextVa) || !IsMappedOnGpuAndPhysical(nextVa))
                     {
                         break;
                     }
@@ -180,7 +228,9 @@ namespace Ryujinx.Graphics.Gpu.Memory
 
             if (isContiguous)
             {
-                return Physical.GetSpan(Translate(va), mappedSize, tracked);
+                (PhysicalMemory physicalMemory, ulong address) = TranslateWithPhysicalMemory(va);
+
+                return physicalMemory.GetSpan(address, mappedSize, tracked);
             }
             else
             {
@@ -190,6 +240,23 @@ namespace Ryujinx.Graphics.Gpu.Memory
 
                 return data;
             }
+        }
+
+        /// <summary>
+        /// Checks if a page of memory is mapped on the GPU and its backing memory.
+        /// </summary>
+        /// <param name="va">GPU virtual address of the page</param>
+        /// <returns>True if mapped, false otherwise</returns>
+        private bool IsMappedOnGpuAndPhysical(ulong va)
+        {
+            (PhysicalMemory physicalMemory, ulong address) = TranslateWithPhysicalMemory(va);
+
+            if (address == PteUnmapped)
+            {
+                return false;
+            }
+
+            return physicalMemory.IsMapped(address);
         }
 
         /// <summary>
@@ -209,22 +276,22 @@ namespace Ryujinx.Graphics.Gpu.Memory
 
             if ((va & PageMask) != 0)
             {
-                ulong pa = Translate(va);
+                (PhysicalMemory physicalMemory, ulong pa) = TranslateWithPhysicalMemory(va);
 
                 size = Math.Min(data.Length, (int)PageSize - (int)(va & PageMask));
 
-                Physical.GetSpan(pa, size, tracked).CopyTo(data[..size]);
+                physicalMemory.GetSpan(pa, size, tracked).CopyTo(data[..size]);
 
                 offset += size;
             }
 
             for (; offset < data.Length; offset += size)
             {
-                ulong pa = Translate(va + (ulong)offset);
+                (PhysicalMemory physicalMemory, ulong pa) = TranslateWithPhysicalMemory(va + (ulong)offset);
 
                 size = Math.Min(data.Length - offset, (int)PageSize);
 
-                Physical.GetSpan(pa, size, tracked).CopyTo(data.Slice(offset, size));
+                physicalMemory.GetSpan(pa, size, tracked).CopyTo(data.Slice(offset, size));
             }
         }
 
@@ -239,15 +306,17 @@ namespace Ryujinx.Graphics.Gpu.Memory
         {
             if (IsContiguous(va, size))
             {
-                return Physical.GetWritableRegion(Translate(va), size, tracked);
+                (PhysicalMemory physicalMemory, ulong address) = TranslateWithPhysicalMemory(va);
+
+                return physicalMemory.GetWritableRegion(address, size, tracked);
             }
             else
             {
-                MemoryOwner<byte> memoryOwner = MemoryOwner<byte>.Rent(size);
+                Memory<byte> memory = new byte[size];
 
-                ReadImpl(va, memoryOwner.Span, tracked);
+                GetSpan(va, size).CopyTo(memory.Span);
 
-                return new WritableRegion(this, va, memoryOwner, tracked);
+                return new WritableRegion(this, va, memory, tracked);
             }
         }
 
@@ -269,7 +338,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// <param name="data">The data to be written</param>
         public void Write(ulong va, ReadOnlySpan<byte> data)
         {
-            WriteImpl(va, data, Physical.Write);
+            WriteImpl(va, data, (physical, va, data) => physical.Write(va, data));
         }
 
         /// <summary>
@@ -279,7 +348,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// <param name="data">The data to be written</param>
         public void WriteTrackedResource(ulong va, ReadOnlySpan<byte> data)
         {
-            WriteImpl(va, data, Physical.WriteTrackedResource);
+            WriteImpl(va, data, (physical, va, data) => physical.WriteTrackedResource(va, data));
         }
 
         /// <summary>
@@ -289,10 +358,10 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// <param name="data">The data to be written</param>
         public void WriteUntracked(ulong va, ReadOnlySpan<byte> data)
         {
-            WriteImpl(va, data, Physical.WriteUntracked);
+            WriteImpl(va, data, (physical, va, data) => physical.WriteUntracked(va, data));
         }
 
-        private delegate void WriteCallback(ulong address, ReadOnlySpan<byte> data);
+        private delegate void WriteCallback(PhysicalMemory physicalMemory, ulong address, ReadOnlySpan<byte> data);
 
         /// <summary>
         /// Writes data to possibly non-contiguous GPU mapped memory.
@@ -304,7 +373,9 @@ namespace Ryujinx.Graphics.Gpu.Memory
         {
             if (IsContiguous(va, data.Length))
             {
-                writeCallback(Translate(va), data);
+                (PhysicalMemory physicalMemory, ulong address) = TranslateWithPhysicalMemory(va);
+
+                writeCallback(physicalMemory, address, data);
             }
             else
             {
@@ -312,22 +383,67 @@ namespace Ryujinx.Graphics.Gpu.Memory
 
                 if ((va & PageMask) != 0)
                 {
-                    ulong pa = Translate(va);
+                    (PhysicalMemory physicalMemory, ulong pa) = TranslateWithPhysicalMemory(va);
 
                     size = Math.Min(data.Length, (int)PageSize - (int)(va & PageMask));
 
-                    writeCallback(pa, data[..size]);
+                    writeCallback(physicalMemory, pa, data[..size]);
 
                     offset += size;
                 }
 
                 for (; offset < data.Length; offset += size)
                 {
-                    ulong pa = Translate(va + (ulong)offset);
+                    (PhysicalMemory physicalMemory, ulong pa) = TranslateWithPhysicalMemory(va + (ulong)offset);
 
                     size = Math.Min(data.Length - offset, (int)PageSize);
 
-                    writeCallback(pa, data.Slice(offset, size));
+                    writeCallback(physicalMemory, pa, data.Slice(offset, size));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Writes data to GPU mapped memory, stopping at the first unmapped page at the memory region, if any.
+        /// </summary>
+        /// <param name="va">GPU virtual address to write the data into</param>
+        /// <param name="data">The data to be written</param>
+        public void WriteMapped(ulong va, ReadOnlySpan<byte> data)
+        {
+            if (IsContiguous(va, data.Length))
+            {
+                (PhysicalMemory physicalMemory, ulong address) = TranslateWithPhysicalMemory(va);
+
+                physicalMemory.Write(address, data);
+            }
+            else
+            {
+                int offset = 0, size;
+
+                if ((va & PageMask) != 0)
+                {
+                    (PhysicalMemory physicalMemory, ulong pa) = TranslateWithPhysicalMemory(va);
+
+                    size = Math.Min(data.Length, (int)PageSize - (int)(va & PageMask));
+
+                    if (pa != PteUnmapped && physicalMemory.IsMapped(pa))
+                    {
+                        physicalMemory.Write(pa, data[..size]);
+                    }
+
+                    offset += size;
+                }
+
+                for (; offset < data.Length; offset += size)
+                {
+                    (PhysicalMemory physicalMemory, ulong pa) = TranslateWithPhysicalMemory(va + (ulong)offset);
+
+                    size = Math.Min(data.Length - offset, (int)PageSize);
+
+                    if (pa != PteUnmapped && physicalMemory.IsMapped(pa))
+                    {
+                        physicalMemory.Write(pa, data.Slice(offset, size));
+                    }
                 }
             }
         }
@@ -360,14 +476,50 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// <param name="kind">Kind of the resource located at the mapping</param>
         public void Map(ulong pa, ulong va, ulong size, PteKind kind)
         {
+            MapImpl(pa, va, size, kind);
+        }
+
+        /// <summary>
+        /// Maps a given range of pages to the specified CPU virtual address from a different process.
+        /// </summary>
+        /// <remarks>
+        /// All addresses and sizes must be page aligned.
+        /// </remarks>
+        /// <param name="pa">CPU virtual address to map into</param>
+        /// <param name="va">GPU virtual address to be mapped</param>
+        /// <param name="size">Size in bytes of the mapping</param>
+        /// <param name="kind">Kind of the resource located at the mapping</param>
+        /// <param name="ownedPid">PID of the process that owns the mapping</param>
+        public void MapForeign(ulong pa, ulong va, ulong size, PteKind kind, ulong ownedPid)
+        {
+            if (_context.PhysicalMemoryRegistry.TryGetValue(ownedPid, out PhysicalMemory physicalMemory))
+            {
+                MapImpl(pa, va, size, kind, physicalMemory);
+            }
+        }
+
+        /// <summary>
+        /// Maps a given range of pages to the specified CPU virtual address.
+        /// </summary>
+        /// <remarks>
+        /// All addresses and sizes must be page aligned.
+        /// </remarks>
+        /// <param name="pa">CPU virtual address to map into</param>
+        /// <param name="va">GPU virtual address to be mapped</param>
+        /// <param name="size">Size in bytes of the mapping</param>
+        /// <param name="kind">Kind of the resource located at the mapping</param>
+        /// <param name="physicalMemory">Optional physical memory to import for the mapping</param>
+        private void MapImpl(ulong pa, ulong va, ulong size, PteKind kind, PhysicalMemory physicalMemory = null)
+        {
             lock (_pageTable)
             {
                 UnmapEventArgs e = new(va, size);
                 MemoryUnmapped?.Invoke(this, e);
+                byte pIndex = physicalMemory != null ? GetOrAddPhysicalMemory(physicalMemory) : (byte)0;
 
                 for (ulong offset = 0; offset < size; offset += PageSize)
                 {
-                    SetPte(va + offset, PackPte(pa + offset, kind));
+                    SetPte(va + offset, PackPte(pa + offset, pIndex, kind));
                 }
 
                 RunRemapActions(e);
@@ -418,12 +570,14 @@ namespace Ryujinx.Graphics.Gpu.Memory
 
             for (int page = 0; page < pages - 1; page++)
             {
-                if (!ValidateAddress(va + PageSize) || GetPte(va + PageSize) == PteUnmapped)
+                ulong nextPte = GetPte(va + PageSize);
+
+                if (!ValidateAddress(va + PageSize) || nextPte == PteUnmapped)
                 {
                     return false;
                 }
 
-                if (Translate(va) + PageSize != Translate(va + PageSize))
+                if (GetPte(va) + PageSize != nextPte)
                 {
                     return false;
                 }
@@ -457,7 +611,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
 
             int pages = (int)((endVaRounded - va) / PageSize);
 
-            List<MemoryRange> regions = [];
+            var regions = new List<MemoryRange>();
 
             for (int page = 0; page < pages - 1; page++)
             {
@@ -533,6 +687,49 @@ namespace Ryujinx.Graphics.Gpu.Memory
             }
 
             return true;
+        }
+
+        /// <summary>
+        /// Gets the backing memory for a given GPU virtual address.
+        /// </summary>
+        /// <param name="va">GPU virtual address to get the backing memory from</param>
+        /// <returns>The backing memory for the specified GPU virtual address</returns>
+        internal PhysicalMemory GetBackingMemory(ulong va)
+        {
+            ulong pte = GetPte(va);
+
+            if (pte == PteUnmapped)
+            {
+                return GetOwnPhysicalMemory();
+            }
+
+            return _physicalMemoryList[UnpackPIndexFromPte(pte)];
+        }
+
+        /// <summary>
+        /// Gets the backing memory that is owned by this GPU memory manager.
+        /// </summary>
+        /// <returns>The backing memory owned by this memory manager</returns>
+        private PhysicalMemory GetOwnPhysicalMemory()
+        {
+            return _physicalMemoryList[0];
+        }
+
+        /// <summary>
+        /// Gets the index for a given physical memory on the list, adding it to the list if needed.
+        /// </summary>
+        /// <param name="physicalMemory">Physical memory to get the index from</param>
+        /// <returns>The index of the physical memory on the list</returns>
+        private byte GetOrAddPhysicalMemory(PhysicalMemory physicalMemory)
+        {
+            if (!_physicalMemoryMap.TryGetValue(physicalMemory, out byte pIndex))
+            {
+                pIndex = checked((byte)_physicalMemoryList.Count);
+                _physicalMemoryList.Add(physicalMemory);
+                _physicalMemoryMap.Add(physicalMemory, pIndex);
+            }
+
+            return pIndex;
         }
 
         /// <summary>
@@ -637,6 +834,28 @@ namespace Ryujinx.Graphics.Gpu.Memory
         }
 
         /// <summary>
+        /// Translates a GPU virtual address to a CPU virtual address and the associated physical memory.
+        /// </summary>
+        /// <param name="va">GPU virtual address to be translated</param>
+        /// <returns>CPU virtual address with the physical memory, or <see cref="PteUnmapped"/> if unmapped</returns>
+        private (PhysicalMemory, ulong) TranslateWithPhysicalMemory(ulong va)
+        {
+            if (!ValidateAddress(va))
+            {
+                return (GetOwnPhysicalMemory(), PteUnmapped);
+            }
+
+            ulong pte = GetPte(va);
+
+            if (pte == PteUnmapped)
+            {
+                return (GetOwnPhysicalMemory(), PteUnmapped);
+            }
+
+            return (_physicalMemoryList[UnpackPIndexFromPte(pte)], UnpackPaFromPte(pte) + (va & PageMask));
+        }
+
+        /// <summary>
         /// Gets the kind of a given memory page.
         /// This might indicate the type of resource that can be allocated on the page, and also texture tiling.
         /// </summary>
@@ -657,6 +876,18 @@ namespace Ryujinx.Graphics.Gpu.Memory
             }
 
             return UnpackKindFromPte(pte);
+        }
+
+        public bool IsForeignMapping(ulong va)
+        {
+            ulong pte = GetPte(va);
+
+            if (pte == PteUnmapped)
+            {
+                return false;
+            }
+
+            return UnpackPIndexFromPte(pte) != 0;
         }
 
         /// <summary>
@@ -704,11 +935,12 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// Creates a page table entry from a physical address and kind.
         /// </summary>
         /// <param name="pa">Physical address</param>
+        /// <param name="pIndex">Index of the physical memory on the list</param>
         /// <param name="kind">Kind</param>
         /// <returns>Page table entry</returns>
-        private static ulong PackPte(ulong pa, PteKind kind)
+        private static ulong PackPte(ulong pa, byte pIndex, PteKind kind)
         {
-            return pa | ((ulong)kind << 56);
+            return pa | ((ulong)pIndex << 48) | ((ulong)kind << 56);
         }
 
         /// <summary>
@@ -722,13 +954,23 @@ namespace Ryujinx.Graphics.Gpu.Memory
         }
 
         /// <summary>
+        /// Unpacks the physical memory index in the list from a page table entry.
+        /// </summary>
+        /// <param name="pte">Page table entry</param>
+        /// <returns>Physical memory index</returns>
+        private static byte UnpackPIndexFromPte(ulong pte)
+        {
+            return (byte)(pte >> 48);
+        }
+
+        /// <summary>
         /// Unpacks physical address from a page table entry.
         /// </summary>
         /// <param name="pte">Page table entry</param>
         /// <returns>Physical address</returns>
         private static ulong UnpackPaFromPte(ulong pte)
         {
-            return pte & 0xffffffffffffffUL;
+            return pte & 0xffffffffffffUL;
         }
     }
 }

--- a/src/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
+++ b/src/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
@@ -611,7 +611,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
 
             int pages = (int)((endVaRounded - va) / PageSize);
 
-            var regions = new List<MemoryRange>();
+            List<MemoryRange> regions = new();
 
             for (int page = 0; page < pages - 1; page++)
             {

--- a/src/Ryujinx.Graphics.Gpu/Memory/VertexBuffer.cs
+++ b/src/Ryujinx.Graphics.Gpu/Memory/VertexBuffer.cs
@@ -7,6 +7,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
     /// </summary>
     struct VertexBuffer
     {
+        public BufferCache BufferCache;
         public MultiRange Range;
         public int Stride;
         public int Divisor;

--- a/src/Ryujinx.Graphics.Gpu/Shader/GpuAccessor.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/GpuAccessor.cs
@@ -66,11 +66,11 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <inheritdoc/>
         public uint ConstantBuffer1Read(int offset)
         {
-            ulong baseAddress = _compute
+            (var physical, ulong baseAddress) = _compute
                 ? _channel.BufferManager.GetComputeUniformBufferAddress(1)
                 : _channel.BufferManager.GetGraphicsUniformBufferAddress(_stageIndex, 1);
 
-            return _channel.MemoryManager.Physical.Read<uint>(baseAddress + (ulong)offset);
+            return physical.Read<uint>(baseAddress + (ulong)offset);
         }
 
         /// <inheritdoc/>

--- a/src/Ryujinx.Graphics.Gpu/Shader/GpuAccessor.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/GpuAccessor.cs
@@ -1,5 +1,6 @@
 using Ryujinx.Common.Logging;
 using Ryujinx.Graphics.Gpu.Image;
+using Ryujinx.Graphics.Gpu.Memory;
 using Ryujinx.Graphics.Shader;
 using Ryujinx.Graphics.Shader.Translation;
 using System;
@@ -66,7 +67,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <inheritdoc/>
         public uint ConstantBuffer1Read(int offset)
         {
-            (var physical, ulong baseAddress) = _compute
+            (PhysicalMemory physical, ulong baseAddress) = _compute
                 ? _channel.BufferManager.GetComputeUniformBufferAddress(1)
                 : _channel.BufferManager.GetGraphicsUniformBufferAddress(_stageIndex, 1);
 

--- a/src/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -733,15 +733,15 @@ namespace Ryujinx.Graphics.Gpu.Shader
             byte[] codeB,
             bool asCompute)
         {
-            ulong cb1DataAddress = channel.BufferManager.GetGraphicsUniformBufferAddress(0, 1);
-
+            (var physical, ulong cb1DataAddress) = channel.BufferManager.GetGraphicsUniformBufferAddress(0, 1);
+            
             MemoryManager memoryManager = channel.MemoryManager;
 
             codeA ??= memoryManager.GetSpan(vertexA.Address, vertexA.Size).ToArray();
             codeB ??= memoryManager.GetSpan(currentStage.Address, currentStage.Size).ToArray();
-            byte[] cb1DataA = ReadArray(memoryManager, cb1DataAddress, vertexA.Cb1DataSize);
-            byte[] cb1DataB = ReadArray(memoryManager, cb1DataAddress, currentStage.Cb1DataSize);
-
+            byte[] cb1DataA = ReadArray(physical, cb1DataAddress, vertexA.Cb1DataSize);
+            byte[] cb1DataB = ReadArray(physical, cb1DataAddress, currentStage.Cb1DataSize);
+            
             ShaderDumpPaths pathsA = default;
             ShaderDumpPaths pathsB = default;
 
@@ -775,11 +775,11 @@ namespace Ryujinx.Graphics.Gpu.Shader
         {
             MemoryManager memoryManager = channel.MemoryManager;
 
-            ulong cb1DataAddress = context.Stage == ShaderStage.Compute
+            (var physical, ulong cb1DataAddress) = context.Stage == ShaderStage.Compute
                 ? channel.BufferManager.GetComputeUniformBufferAddress(1)
                 : channel.BufferManager.GetGraphicsUniformBufferAddress(StageToStageIndex(context.Stage), 1);
 
-            byte[] cb1Data = ReadArray(memoryManager, cb1DataAddress, context.Cb1DataSize);
+            byte[] cb1Data = ReadArray(physical, cb1DataAddress, context.Cb1DataSize);
             code ??= memoryManager.GetSpan(context.Address, context.Size).ToArray();
 
             ShaderDumpPaths paths = dumper?.Dump(code, context.Stage == ShaderStage.Compute) ?? default;
@@ -793,18 +793,18 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <summary>
         /// Reads data from physical memory, returns an empty array if the memory is unmapped or size is 0.
         /// </summary>
-        /// <param name="memoryManager">Memory manager with the physical memory to read from</param>
+        /// <param name="physicalMemory">Physical memory to read the data from, might be null</param>
         /// <param name="address">Physical address of the region to read</param>
         /// <param name="size">Size in bytes of the data</param>
         /// <returns>An array with the data at the specified memory location</returns>
-        private static byte[] ReadArray(MemoryManager memoryManager, ulong address, int size)
+        private static byte[] ReadArray(PhysicalMemory physicalMemory, ulong address, int size)
         {
-            if (address == MemoryManager.PteUnmapped || size == 0)
+            if (address == MemoryManager.PteUnmapped || size == 0 || physicalMemory == null)            
             {
                 return [];
             }
 
-            return memoryManager.Physical.GetSpan(address, size).ToArray();
+            return physicalMemory.GetSpan(address, size).ToArray();
         }
 
         /// <summary>

--- a/src/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -733,7 +733,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
             byte[] codeB,
             bool asCompute)
         {
-            (var physical, ulong cb1DataAddress) = channel.BufferManager.GetGraphicsUniformBufferAddress(0, 1);
+            (PhysicalMemory physical, ulong cb1DataAddress) = channel.BufferManager.GetGraphicsUniformBufferAddress(0, 1);
             
             MemoryManager memoryManager = channel.MemoryManager;
 
@@ -775,7 +775,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         {
             MemoryManager memoryManager = channel.MemoryManager;
 
-            (var physical, ulong cb1DataAddress) = context.Stage == ShaderStage.Compute
+            (PhysicalMemory physical, ulong cb1DataAddress) = context.Stage == ShaderStage.Compute
                 ? channel.BufferManager.GetComputeUniformBufferAddress(1)
                 : channel.BufferManager.GetGraphicsUniformBufferAddress(StageToStageIndex(context.Stage), 1);
 

--- a/src/Ryujinx.Graphics.Gpu/Shader/ShaderSpecializationState.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/ShaderSpecializationState.cs
@@ -696,7 +696,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
             {
                 ref BufferBounds bounds = ref channel.BufferManager.GetUniformBufferBounds(isCompute, stageIndex, textureBufferIndex);
 
-                cachedTextureBuffer = MemoryMarshal.Cast<byte, int>(channel.MemoryManager.Physical.GetSpan(bounds.Range));
+                cachedTextureBuffer = MemoryMarshal.Cast<byte, int>(bounds.Physical.GetSpan(bounds.Range));
                 cachedTextureBufferIndex = textureBufferIndex;
 
                 if (samplerBufferIndex == textureBufferIndex)
@@ -710,7 +710,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
             {
                 ref BufferBounds bounds = ref channel.BufferManager.GetUniformBufferBounds(isCompute, stageIndex, samplerBufferIndex);
 
-                cachedSamplerBuffer = MemoryMarshal.Cast<byte, int>(channel.MemoryManager.Physical.GetSpan(bounds.Range));
+                cachedSamplerBuffer = MemoryMarshal.Cast<byte, int>(bounds.Physical.GetSpan(bounds.Range));
                 cachedSamplerBufferIndex = samplerBufferIndex;
             }
 

--- a/src/Ryujinx.Graphics.Gpu/Window.cs
+++ b/src/Ryujinx.Graphics.Gpu/Window.cs
@@ -9,11 +9,18 @@ using System.Threading;
 
 namespace Ryujinx.Graphics.Gpu
 {
+    using Texture = Image.Texture;
+
+    public record TextureData(int Width, int Height, byte[] Data);
+
     /// <summary>
     /// GPU image presentation window.
     /// </summary>
     public class Window
     {
+        private const int CaptureTextureWidth = 1280;
+        private const int CaptureTextureHeight = 720;
+
         private readonly GpuContext _context;
 
         /// <summary>
@@ -85,7 +92,21 @@ namespace Ryujinx.Graphics.Gpu
             }
         }
 
+        private class PresentedTexture
+        {
+            public readonly Texture Texture;
+            public readonly ImageCrop Crop;
+
+            public PresentedTexture(Texture texture, ImageCrop crop)
+            {
+                Texture = texture;
+                Crop = crop;
+            }
+        }
+
         private readonly ConcurrentQueue<PresentationTexture> _frameQueue;
+        private PresentedTexture _lastPresentedTexture;
+        private ITexture _captureTexture;
 
         private int _framesAvailable;
 
@@ -188,6 +209,51 @@ namespace Ryujinx.Graphics.Gpu
             return true;
         }
 
+        public TextureData GetLastPresentedData()
+        {
+            PresentedTexture pt = Volatile.Read(ref _lastPresentedTexture);
+
+            if (pt != null)
+            {
+                byte[] inputData = CaptureLastFrame(pt.Texture.HostTexture, pt.Crop);
+
+                int size = SizeCalculator.GetBlockLinearTextureSize(
+                    CaptureTextureWidth,
+                    CaptureTextureHeight,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    4,
+                    16,
+                    1,
+                    1).TotalSize;
+
+                byte[] data = new byte[size];
+
+                LayoutConverter.ConvertLinearToBlockLinear(data, CaptureTextureWidth, CaptureTextureHeight, CaptureTextureWidth * 4, 4, 16, inputData);
+
+                return new TextureData(CaptureTextureWidth, CaptureTextureHeight, data);
+            }
+
+            return new TextureData(0, 0, Array.Empty<byte>());
+        }
+
+        public TextureData GetLastPresentedDataLinear()
+        {
+            PresentedTexture pt = Volatile.Read(ref _lastPresentedTexture);
+
+            if (pt != null)
+            {
+                byte[] inputData = CaptureLastFrame(pt.Texture.HostTexture, new ImageCrop());
+
+                return new TextureData(pt.Texture.Info.Width, pt.Texture.Info.Height, inputData);
+            }
+
+            return new TextureData(0, 0, Array.Empty<byte>());
+        }
+
         /// <summary>
         /// Presents a texture on the queue.
         /// If the queue is empty, then no texture is presented.
@@ -204,6 +270,10 @@ namespace Ryujinx.Graphics.Gpu
                 Image.Texture texture = pt.Cache.FindOrCreateTexture(null, TextureSearchFlags.WithUpscale, pt.Info, 0, range: pt.Range);
 
                 pt.Cache.Tick();
+
+                EnsureCaptureTexture();
+
+                Volatile.Write(ref _lastPresentedTexture, new PresentedTexture(texture, pt.Crop));
 
                 texture.SynchronizeMemory();
 
@@ -242,6 +312,96 @@ namespace Ryujinx.Graphics.Gpu
 
                 pt.ReleaseCallback(pt.UserObj);
             }
+        }
+
+        private void EnsureCaptureTexture()
+        {
+            if (_captureTexture == null)
+            {
+                _captureTexture = _context.Renderer.CreateTexture(new TextureCreateInfo(
+                    1280,
+                    720,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    4,
+                    Format.R8G8B8A8Unorm,
+                    DepthStencilMode.Depth,
+                    Target.Texture2D,
+                    SwizzleComponent.Red,
+                    SwizzleComponent.Green,
+                    SwizzleComponent.Blue,
+                    SwizzleComponent.Alpha));
+            }
+        }
+
+        private byte[] CaptureLastFrame(ITexture lastFrame, ImageCrop crop)
+        {
+            int cropLeft, cropRight, cropTop, cropBottom;
+
+            if (crop.Left == 0 && crop.Right == 0)
+            {
+                cropLeft = 0;
+                cropRight = lastFrame.Width;
+            }
+            else
+            {
+                cropLeft = crop.Left;
+                cropRight = crop.Right;
+            }
+
+            if (crop.Top == 0 && crop.Bottom == 0)
+            {
+                cropTop = 0;
+                cropBottom = lastFrame.Height;
+            }
+            else
+            {
+                cropTop = crop.Top;
+                cropBottom = crop.Bottom;
+            }
+
+            int x1, y1, x2, y2;
+
+            if (crop.FlipX)
+            {
+                x1 = cropRight;
+                x2 = cropLeft;
+            }
+            else
+            {
+                x1 = cropLeft;
+                x2 = cropRight;
+            }
+
+            if (crop.FlipY)
+            {
+                y1 = cropBottom;
+                y2 = cropTop;
+            }
+            else
+            {
+                y1 = cropTop;
+                y2 = cropBottom;
+            }
+
+            Extents2D srcRegion = new(x1, y1, x2, y2);
+            Extents2D dstRegion = new(0, 0, CaptureTextureWidth, CaptureTextureHeight);
+
+            byte[] outputData = null;
+
+            _context.Renderer.BackgroundContextAction(() =>
+            {
+                lastFrame.CopyTo(_captureTexture, srcRegion, dstRegion, true);
+
+                using var data = _captureTexture.GetData();
+
+                outputData = data.Get().ToArray();
+            });
+
+            return outputData;
         }
 
         /// <summary>

--- a/src/Ryujinx.HLE/HOS/ArmProcessContext.cs
+++ b/src/Ryujinx.HLE/HOS/ArmProcessContext.cs
@@ -24,7 +24,7 @@ namespace Ryujinx.HLE.HOS
         private readonly ICpuContext _cpuContext;
         private T _memoryManager;
 
-        public IVirtualMemoryManager AddressSpace => _memoryManager;
+        public IVirtualMemoryManagerTracked AddressSpace => _memoryManager;
 
         public ulong AddressSpaceSize { get; }
 

--- a/src/Ryujinx.HLE/HOS/Horizon.cs
+++ b/src/Ryujinx.HLE/HOS/Horizon.cs
@@ -75,7 +75,7 @@ namespace Ryujinx.HLE.HOS
         internal ServerBase TimeServer { get; private set; }
         internal ServerBase ViServer { get; private set; }
         internal ServerBase ViServerM { get; private set; }
-        internal ServerBase ViServerS { get; private set; }
+        internal ViServer ViServerS { get; private set; }
         internal ServerBase LdnServer { get; private set; }
 
         internal KSharedMemory HidSharedMem { get; private set; }
@@ -254,7 +254,7 @@ namespace Ryujinx.HLE.HOS
             TimeServer = new ServerBase(KernelContext, "TimeServer");
             ViServer = new ServerBase(KernelContext, "ViServerU");
             ViServerM = new ServerBase(KernelContext, "ViServerM");
-            ViServerS = new ServerBase(KernelContext, "ViServerS");
+            ViServerS = new ViServer(KernelContext, "ViServerS");
             LdnServer = new ServerBase(KernelContext, "LdnServer");
 
             StartNewServices();

--- a/src/Ryujinx.HLE/HOS/Kernel/Process/IProcessContext.cs
+++ b/src/Ryujinx.HLE/HOS/Kernel/Process/IProcessContext.cs
@@ -6,7 +6,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
 {
     interface IProcessContext : IDisposable
     {
-        IVirtualMemoryManager AddressSpace { get; }
+        IVirtualMemoryManagerTracked AddressSpace { get; }
 
         ulong AddressSpaceSize { get; }
 

--- a/src/Ryujinx.HLE/HOS/Kernel/Process/KProcess.cs
+++ b/src/Ryujinx.HLE/HOS/Kernel/Process/KProcess.cs
@@ -86,7 +86,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
 
         private IProcessContextFactory _contextFactory;
         public IProcessContext Context { get; private set; }
-        public IVirtualMemoryManager CpuMemory => Context.AddressSpace;
+        public IVirtualMemoryManagerTracked CpuMemory => Context.AddressSpace;
 
         public HleProcessDebugger Debugger { get; private set; }
 

--- a/src/Ryujinx.HLE/HOS/Kernel/Process/ProcessContext.cs
+++ b/src/Ryujinx.HLE/HOS/Kernel/Process/ProcessContext.cs
@@ -6,11 +6,11 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
 {
     class ProcessContext : IProcessContext
     {
-        public IVirtualMemoryManager AddressSpace { get; }
+        public IVirtualMemoryManagerTracked AddressSpace { get; }
 
         public ulong AddressSpaceSize { get; }
 
-        public ProcessContext(IVirtualMemoryManager asManager, ulong addressSpaceSize)
+        public ProcessContext(IVirtualMemoryManagerTracked asManager, ulong addressSpaceSize)
         {
             AddressSpace = asManager;
             AddressSpaceSize = addressSpaceSize;

--- a/src/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/IDisplayController.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/IDisplayController.cs
@@ -102,5 +102,26 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
 
             return ResultCode.Success;
         }
+        
+        [CommandCmif(22)]
+        // AcquireLastApplicationCaptureSharedBuffer() -> (b8, u32)
+        public ResultCode AcquireLastApplicationCaptureSharedBuffer(ServiceCtx context)
+        {
+            context.ResponseData.Write(1);
+            context.ResponseData.Write(context.Device.System.ViServerS.GetApplicationLastPresentedFrameHandle(context.Device.Gpu));
+
+            return ResultCode.Success;
+        }
+
+        [CommandCmif(26)]
+        // AcquireCallerAppletCaptureSharedBuffer() -> (b8, u32)
+        public ResultCode AcquireCallerAppletCaptureSharedBuffer(ServiceCtx context)
+        {
+            // TODO: How does the handling for applets differ from the one for applications?
+            context.ResponseData.Write(1);
+            context.ResponseData.Write(context.Device.System.ViServerS.GetApplicationLastPresentedFrameHandle(context.Device.Gpu));
+
+            return ResultCode.Success;
+        }
     }
 }

--- a/src/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/IDisplayController.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/IDisplayController.cs
@@ -114,6 +114,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         }
 
         [CommandCmif(26)]
+        
         // AcquireCallerAppletCaptureSharedBuffer() -> (b8, u32)
         public ResultCode AcquireCallerAppletCaptureSharedBuffer(ServiceCtx context)
         {
@@ -121,6 +122,13 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             context.ResponseData.Write(1);
             context.ResponseData.Write(context.Device.System.ViServerS.GetApplicationLastPresentedFrameHandle(context.Device.Gpu));
 
+            return ResultCode.Success;
+        }
+        
+        [CommandCmif(27)]
+        public ResultCode ReleaseCallerAppletCaptureSharedBuffer(ServiceCtx context)
+        {
+            context.ResponseData.Write(2);
             return ResultCode.Success;
         }
     }

--- a/src/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ISelfController.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ISelfController.cs
@@ -238,16 +238,27 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         {
             // NOTE: Service checks a private field and return an error if the SystemBufferSharing is disabled.
 
-            return ResultCode.NotImplemented;
+            // todo check if we're not an AppletId.Application   
+            return ResultCode.Success;
         }
 
+        [CommandCmif(42)] // 4.0.0+
+        // GetSystemSharedLayerHandle() -> (nn::vi::fbshare::SharedBufferHandle, nn::vi::fbshare::SharedLayerHandle)
+        public ResultCode GetSystemSharedLayerHandle(ServiceCtx context)
+        {
+            context.ResponseData.Write((ulong)context.Device.System.ViServerS.GetSharedBufferNvMapId());
+            context.ResponseData.Write(context.Device.System.ViServerS.GetSharedLayerId());
+
+            return ResultCode.Success;
+        }
+        
         [CommandCmif(44)] // 10.0.0+
         // CreateManagedDisplaySeparableLayer() -> (u64, u64)
         public ResultCode CreateManagedDisplaySeparableLayer(ServiceCtx context)
         {
             context.Device.System.SurfaceFlinger.CreateLayer(out long displayLayerId, _pid);
             context.Device.System.SurfaceFlinger.CreateLayer(out long recordingLayerId, _pid);
-            context.Device.System.SurfaceFlinger.SetRenderLayer(displayLayerId);
+            //context.Device.System.SurfaceFlinger.SetRenderLayer(displayLayerId);
 
             context.ResponseData.Write(displayLayerId);
             context.ResponseData.Write(recordingLayerId);

--- a/src/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ISelfController.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ISelfController.cs
@@ -225,7 +225,6 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         public ResultCode CreateManagedDisplayLayer(ServiceCtx context)
         {
             context.Device.System.SurfaceFlinger.CreateLayer(out long layerId, _pid);
-            context.Device.System.SurfaceFlinger.SetRenderLayer(layerId);
 
             context.ResponseData.Write(layerId);
 
@@ -236,9 +235,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         // IsSystemBufferSharingEnabled()
         public ResultCode IsSystemBufferSharingEnabled(ServiceCtx context)
         {
-            // NOTE: Service checks a private field and return an error if the SystemBufferSharing is disabled.
-
-            // todo check if we're not an AppletId.Application   
+            // TODO: Implement this once we have a way to check if we're not an AppletId.Application   
             return ResultCode.Success;
         }
 

--- a/src/Ryujinx.HLE/HOS/Services/Hid/HidDevices/NpadDevices.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Hid/HidDevices/NpadDevices.cs
@@ -35,6 +35,8 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
         public Dictionary<PlayerIndex, ConcurrentQueue<(VibrationValue, VibrationValue)>> RumbleQueues = new();
         public Dictionary<PlayerIndex, (VibrationValue, VibrationValue)> LastVibrationValues = new();
+        
+        internal PlayerIndex LastActiveNpad { get; set; }
 
         public NpadDevices(Switch device, bool active = true) : base(device, active)
         {
@@ -384,6 +386,8 @@ namespace Ryujinx.HLE.HOS.Services.Hid
                 return;
             }
 
+            LastActiveNpad = state.PlayerId;
+            
             ref RingLifo<NpadCommonState> lifo = ref GetCommonStateLifo(ref currentNpad);
 
             NpadCommonState newState = new()
@@ -638,6 +642,21 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             }
 
             return rumbleQueue;
+        }
+        
+        public NpadIdType GetLastActiveNpadId()
+        {
+            return LastActiveNpad switch {
+                PlayerIndex.Player1 => NpadIdType.Player1,
+                PlayerIndex.Player2 => NpadIdType.Player2,
+                PlayerIndex.Player3 => NpadIdType.Player3,
+                PlayerIndex.Player4 => NpadIdType.Player4,
+                PlayerIndex.Player5 => NpadIdType.Player5,
+                PlayerIndex.Player6 => NpadIdType.Player6,
+                PlayerIndex.Player7 => NpadIdType.Player7,
+                PlayerIndex.Player8 => NpadIdType.Player8,
+                _ => NpadIdType.Handheld,
+            };
         }
     }
 }

--- a/src/Ryujinx.HLE/HOS/Services/Hid/IHidSystemServer.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Hid/IHidSystemServer.cs
@@ -24,15 +24,9 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         // GetLastActiveNpad(u32) -> u8, u8
         public ResultCode GetLastActiveNpad(ServiceCtx context)
         {
-            // TODO: RequestData seems to have garbage data, reading an extra uint seems to fix the issue.
-            context.RequestData.ReadUInt32();
+            context.ResponseData.Write((byte)context.Device.Hid.Npads.GetLastActiveNpadId());
 
-            ResultCode resultCode = GetAppletFooterUiTypeImpl(context, out AppletFooterUiType appletFooterUiType);
-
-            context.ResponseData.Write((byte)appletFooterUiType);
-            context.ResponseData.Write((byte)0);
-
-            return resultCode;
+            return ResultCode.Success;
         }
 
         [CommandCmif(307)]

--- a/src/Ryujinx.HLE/HOS/Services/Nifm/StaticService/IRequest.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Nifm/StaticService/IRequest.cs
@@ -1,3 +1,4 @@
+using Ryujinx.Common;
 using Ryujinx.Common.Logging;
 using Ryujinx.HLE.HOS.Ipc;
 using Ryujinx.HLE.HOS.Kernel.Threading;
@@ -105,6 +106,26 @@ namespace Ryujinx.HLE.HOS.Services.Nifm.StaticService
             return ResultCode.Success;
         }
 
+        [CommandCmif(6)]
+        // SetRequirementPreset(u32)
+        public ResultCode SetRequirementPreset(ServiceCtx context)
+        {
+            Logger.Stub?.PrintStub(LogClass.ServiceNifm);
+
+            return ResultCode.Success;
+        }
+
+        [CommandCmif(9)]
+        // SetNetworkProfileId(nn::util::Uuid)
+        public ResultCode SetNetworkProfileId(ServiceCtx context)
+        {
+            UInt128 uuid = context.RequestData.ReadStruct<UInt128>();
+
+            Logger.Stub?.PrintStub(LogClass.ServiceNifm, new { uuid });
+
+            return ResultCode.Success;
+        }
+
         [CommandCmif(11)]
         // SetConnectionConfirmationOption(i8)
         public ResultCode SetConnectionConfirmationOption(ServiceCtx context)
@@ -139,6 +160,39 @@ namespace Ryujinx.HLE.HOS.Services.Nifm.StaticService
             context.ResponseData.Write(0xe); // Use error applet as default for now
             context.ResponseData.Write(0); // libraryAppletMode
             context.ResponseData.Write(0); // outSize
+
+            return ResultCode.Success;
+        }
+
+        [CommandCmif(23)]
+        // SetKeptInSleep(bool)
+        public ResultCode SetKeptInSleep(ServiceCtx context)
+        {
+            bool keptInSleep = context.RequestData.ReadBoolean();
+
+            Logger.Stub?.PrintStub(LogClass.ServiceNifm, new { keptInSleep });
+
+            return ResultCode.Success;
+        }
+
+        [CommandCmif(24)]
+        // RegisterSocketDescriptor(s32)
+        public ResultCode RegisterSocketDescriptor(ServiceCtx context)
+        {
+            int socketDescriptor = context.RequestData.ReadInt32();
+
+            Logger.Stub?.PrintStub(LogClass.ServiceNifm, new { socketDescriptor });
+
+            return ResultCode.Success;
+        }
+
+        [CommandCmif(25)]
+        // UnregisterSocketDescriptor(s32)
+        public ResultCode UnregisterSocketDescriptor(ServiceCtx context)
+        {
+            int socketDescriptor = context.RequestData.ReadInt32();
+
+            Logger.Stub?.PrintStub(LogClass.ServiceNifm, new { socketDescriptor });
 
             return ResultCode.Success;
         }

--- a/src/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostChannel/NvHostChannelDeviceFile.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostChannel/NvHostChannelDeviceFile.cs
@@ -167,8 +167,8 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostChannel
 
                 foreach (CommandBuffer commandBuffer in commandBuffers)
                 {
-                    NvMapHandle map = NvMapDeviceFile.GetMapFromHandle(Owner, commandBuffer.Mem);
-
+                    NvMapHandle map = NvMapDeviceFile.GetMapFromHandle(commandBuffer.Mem);
+                    
                     ReadOnlySpan<byte> data = _memory.GetSpan(map.Address + commandBuffer.Offset, commandBuffer.WordsCount * 4);
 
                     _host1xContext.Host1x.Submit(MemoryMarshal.Cast<byte, int>(data), _contextId);
@@ -237,8 +237,8 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostChannel
 
             foreach (ref CommandBufferHandle commandBufferEntry in commandBufferEntries)
             {
-                NvMapHandle map = NvMapDeviceFile.GetMapFromHandle(Owner, commandBufferEntry.MapHandle);
-
+                NvMapHandle map = NvMapDeviceFile.GetMapFromHandle(commandBufferEntry.MapHandle);
+                
                 if (map == null)
                 {
                     Logger.Warning?.Print(LogClass.ServiceNv, $"Invalid handle 0x{commandBufferEntry.MapHandle:x8}!");
@@ -279,8 +279,8 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostChannel
 
             foreach (ref CommandBufferHandle commandBufferEntry in commandBufferEntries)
             {
-                NvMapHandle map = NvMapDeviceFile.GetMapFromHandle(Owner, commandBufferEntry.MapHandle);
-
+                NvMapHandle map = NvMapDeviceFile.GetMapFromHandle(commandBufferEntry.MapHandle);
+                
                 if (map == null)
                 {
                     Logger.Warning?.Print(LogClass.ServiceNv, $"Invalid handle 0x{commandBufferEntry.MapHandle:x8}!");

--- a/src/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvMap/Types/NvMapHandle.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvMap/Types/NvMapHandle.cs
@@ -14,7 +14,8 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvMap
         public ulong Address;
         public bool Allocated;
         public ulong DmaMapAddress;
-
+        public ulong OwnerPid;
+        
         private long _dupes;
 
         public NvMapHandle()

--- a/src/Ryujinx.HLE/HOS/Services/SurfaceFlinger/SurfaceFlinger.cs
+++ b/src/Ryujinx.HLE/HOS/Services/SurfaceFlinger/SurfaceFlinger.cs
@@ -413,8 +413,8 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
 
             ulong bufferOffset = (ulong)item.GraphicBuffer.Object.Buffer.Surfaces[0].Offset;
 
-            NvMapHandle map = NvMapDeviceFile.GetMapFromHandle(layer.Owner, nvMapHandle);
-
+            NvMapHandle map = NvMapDeviceFile.GetMapFromHandle(nvMapHandle);
+            
             ulong frameBufferAddress = map.Address + bufferOffset;
 
             Format format = ConvertColorFormat(item.GraphicBuffer.Object.Buffer.Surfaces[0].ColorFormat);

--- a/src/Ryujinx.HLE/HOS/Services/SurfaceFlinger/Types/NvGraphicBuffer.cs
+++ b/src/Ryujinx.HLE/HOS/Services/SurfaceFlinger/Types/NvGraphicBuffer.cs
@@ -1,3 +1,4 @@
+using Ryujinx.Common.Memory;
 using System.Runtime.InteropServices;
 
 namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
@@ -36,6 +37,6 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
         public int PlanesCount;
 
         [FieldOffset(0x34)]
-        public NvGraphicBufferSurfaceArray Surfaces;
+        public Array3<NvGraphicBufferSurface> Surfaces;
     }
 }

--- a/src/Ryujinx.HLE/HOS/Services/Vi/RootService/ApplicationDisplayService/IManagerDisplayService.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Vi/RootService/ApplicationDisplayService/IManagerDisplayService.cs
@@ -40,7 +40,6 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService.ApplicationDisplayService
             ulong pid = context.Device.System.AppletState.AppletResourceUserIds.GetData<ulong>((int)appletResourceUserId);
 
             context.Device.System.SurfaceFlinger.CreateLayer(out long layerId, pid);
-            context.Device.System.SurfaceFlinger.SetRenderLayer(layerId);
 
             context.ResponseData.Write(layerId);
 

--- a/src/Ryujinx.HLE/HOS/Services/Vi/RootService/ApplicationDisplayService/ISystemDisplayService.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Vi/RootService/ApplicationDisplayService/ISystemDisplayService.cs
@@ -1,4 +1,11 @@
+using Ryujinx.Common;
 using Ryujinx.Common.Logging;
+using Ryujinx.HLE.HOS.Ipc;
+using Ryujinx.HLE.HOS.Kernel.Threading;
+using Ryujinx.HLE.HOS.Services.SurfaceFlinger;
+using Ryujinx.HLE.HOS.Services.Vi.RootService.ApplicationDisplayService.Types.Fbshare;
+using Ryujinx.Horizon.Common;
+using System;
 
 namespace Ryujinx.HLE.HOS.Services.Vi.RootService.ApplicationDisplayService
 {
@@ -7,6 +14,9 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService.ApplicationDisplayService
 #pragma warning disable IDE0052 // Remove unread private member
         private readonly IApplicationDisplayService _applicationDisplayService;
 #pragma warning restore IDE0052
+        
+        private KEvent _sharedFramebufferAcquirableEvent;
+        private int _sharedFramebufferAcquirableEventHandle;
 
         public ISystemDisplayService(IApplicationDisplayService applicationDisplayService)
         {
@@ -54,6 +64,139 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService.ApplicationDisplayService
             context.ResponseData.Write(0);
 
             Logger.Stub?.PrintStub(LogClass.ServiceVi);
+
+            return ResultCode.Success;
+        }
+        
+        [CommandCmif(8225)] // 4.0.0+
+        // GetSharedBufferMemoryHandleId()
+        public ResultCode GetSharedBufferMemoryHandleId(ServiceCtx context)
+        {
+            context.ResponseData.Write((ulong)context.Device.System.ViServerS.GetSharedBufferNvMapId());
+            context.ResponseData.Write(context.Device.System.ViServerS.GetSharedBufferSize());
+
+            (ulong mapAddress, ulong mapSize) = context.Request.GetBufferType0x22();
+
+            context.Memory.Write(mapAddress, context.Device.System.ViServerS.GetSharedBufferMap());
+
+            return ResultCode.Success;
+        }
+
+        [CommandCmif(8250)] // 4.0.0+
+        // OpenSharedLayer(nn::vi::fbshare::SharedLayerHandle, nn::applet::AppletResourceUserId, pid)
+        public ResultCode OpenSharedLayer(ServiceCtx context)
+        {
+            long sharedLayerHandle = context.RequestData.ReadInt64();
+            long appletResourceUserId = context.RequestData.ReadInt64();
+
+            context.Device.System.ViServerS.OpenSharedLayer(sharedLayerHandle);
+
+            return ResultCode.Success;
+        }
+
+        [CommandCmif(8251)] // 4.0.0+
+        // CloseSharedLayer(nn::vi::fbshare::SharedLayerHandle)
+        public ResultCode CloseSharedLayer(ServiceCtx context)
+        {
+            long sharedLayerHandle = context.RequestData.ReadInt64();
+
+            context.Device.System.ViServerS.CloseSharedLayer(sharedLayerHandle);
+
+            return ResultCode.Success;
+        }
+
+        [CommandCmif(8252)] // 4.0.0+
+        // ConnectSharedLayer(nn::vi::fbshare::SharedLayerHandle)
+        public ResultCode ConnectSharedLayer(ServiceCtx context)
+        {
+            long sharedLayerHandle = context.RequestData.ReadInt64();
+
+            context.Device.System.ViServerS.ConnectSharedLayer(sharedLayerHandle);
+
+            return ResultCode.Success;
+        }
+
+        [CommandCmif(8253)] // 4.0.0+
+        // DisconnectSharedLayer(nn::vi::fbshare::SharedLayerHandle)
+        public ResultCode DisconnectSharedLayer(ServiceCtx context)
+        {
+            long sharedLayerHandle = context.RequestData.ReadInt64();
+
+            context.Device.System.ViServerS.DisconnectSharedLayer(sharedLayerHandle);
+
+            return ResultCode.Success;
+        }
+
+        [CommandCmif(8254)] // 4.0.0+
+        // AcquireSharedFrameBuffer(nn::vi::fbshare::SharedLayerHandle) -> (nn::vi::native::NativeSync, nn::vi::fbshare::SharedLayerTextureIndexList, u64)
+        public ResultCode AcquireSharedFrameBuffer(ServiceCtx context)
+        {
+            long sharedLayerHandle = context.RequestData.ReadInt64();
+
+            int slot = context.Device.System.ViServerS.DequeueFrameBuffer(sharedLayerHandle, out AndroidFence fence);
+
+            var indexList = new SharedLayerTextureIndexList();
+
+            for (int i = 0; i < indexList.Indices.Length; i++)
+            {
+                indexList.Indices[i] = context.Device.System.ViServerS.GetFrameBufferMapIndex(i);
+            }
+
+            context.ResponseData.WriteStruct(fence);
+            context.ResponseData.WriteStruct(indexList);
+            context.ResponseData.Write(0); // Padding
+            context.ResponseData.Write((ulong)slot);
+
+            return ResultCode.Success;
+        }
+
+        [CommandCmif(8255)] // 4.0.0+
+        // PresentSharedFrameBuffer(nn::vi::native::NativeSync, nn::vi::CropRegion, u32, u32, nn::vi::fbshare::SharedLayerHandle, u64)
+        public ResultCode PresentSharedFrameBuffer(ServiceCtx context)
+        {
+            AndroidFence nativeSync = context.RequestData.ReadStruct<AndroidFence>();
+            Rect cropRegion = context.RequestData.ReadStruct<Rect>();
+
+            NativeWindowTransform transform = (NativeWindowTransform)context.RequestData.ReadUInt32();
+            int swapInterval = context.RequestData.ReadInt32();
+            int padding = context.RequestData.ReadInt32();
+
+            long sharedLayerHandle = context.RequestData.ReadInt64();
+            ulong slot = context.RequestData.ReadUInt64();
+
+            context.Device.System.ViServerS.QueueFrameBuffer(sharedLayerHandle, (int)slot, cropRegion, transform, swapInterval, nativeSync);
+
+            return ResultCode.Success;
+        }
+
+        [CommandCmif(8256)] // 4.0.0+
+        // GetSharedFrameBufferAcquirableEvent(nn::vi::fbshare::SharedLayerHandle) -> handle<copy>
+        public ResultCode GetSharedFrameBufferAcquirableEvent(ServiceCtx context)
+        {
+            if (_sharedFramebufferAcquirableEventHandle == 0)
+            {
+                _sharedFramebufferAcquirableEvent = new KEvent(context.Device.System.KernelContext);
+                _sharedFramebufferAcquirableEvent.WritableEvent.Signal();
+
+                if (context.Process.HandleTable.GenerateHandle(_sharedFramebufferAcquirableEvent.ReadableEvent, out _sharedFramebufferAcquirableEventHandle) != Result.Success)
+                {
+                    throw new InvalidOperationException("Out of handles!");
+                }
+            }
+
+            context.Response.HandleDesc = IpcHandleDesc.MakeCopy(_sharedFramebufferAcquirableEventHandle);
+
+            return ResultCode.Success;
+        }
+
+        [CommandCmif(8258)] // 5.0.0+
+        // CancelSharedFrameBuffer(nn::vi::fbshare::SharedLayerHandle, u64)
+        public ResultCode CancelSharedFrameBuffer(ServiceCtx context)
+        {
+            long sharedLayerHandle = context.RequestData.ReadInt64();
+            ulong slot = context.RequestData.ReadUInt64();
+
+            context.Device.System.ViServerS.CancelFrameBuffer(sharedLayerHandle, (int)slot);
 
             return ResultCode.Success;
         }

--- a/src/Ryujinx.HLE/HOS/Services/Vi/RootService/ApplicationDisplayService/Types/Fbshare/SharedLayerTextureIndexList.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Vi/RootService/ApplicationDisplayService/Types/Fbshare/SharedLayerTextureIndexList.cs
@@ -1,0 +1,11 @@
+﻿using Ryujinx.Common.Memory;
+using System.Runtime.InteropServices;
+
+namespace Ryujinx.HLE.HOS.Services.Vi.RootService.ApplicationDisplayService.Types.Fbshare
+{
+    [StructLayout(LayoutKind.Sequential, Size = 0x10, Pack = 0x4)]
+    struct SharedLayerTextureIndexList
+    {
+        public Array4<int> Indices;
+    }
+}

--- a/src/Ryujinx.HLE/HOS/Services/Vi/RootService/IApplicationDisplayService.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Vi/RootService/IApplicationDisplayService.cs
@@ -248,8 +248,6 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService
                 return result;
             }
 
-            context.Device.System.SurfaceFlinger.SetRenderLayer(layerId);
-
             using Parcel parcel = new(0x28, 0x4);
 
             parcel.WriteObject(producer, "dispdrv\0");
@@ -285,9 +283,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService
 
             // TODO: support multi display.
             IBinder producer = context.Device.System.SurfaceFlinger.CreateLayer(out long layerId, 0, LayerState.Stray);
-
-            context.Device.System.SurfaceFlinger.SetRenderLayer(layerId);
-
+            
             using Parcel parcel = new(0x28, 0x4);
 
             parcel.WriteObject(producer, "dispdrv\0");

--- a/src/Ryujinx.HLE/HOS/Services/Vi/Types/SharedBufferMap.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Vi/Types/SharedBufferMap.cs
@@ -1,0 +1,19 @@
+﻿using Ryujinx.Common.Memory;
+
+namespace Ryujinx.HLE.HOS.Services.Vi.Types
+{
+    struct SharedBufferMap
+    {
+        public struct Entry
+        {
+            public ulong Offset;
+            public ulong Size;
+            public uint Width;
+            public uint Height;
+        }
+
+        public int Count;
+        public int Padding;
+        public Array16<Entry> SharedBuffers;
+    }
+}

--- a/src/Ryujinx.HLE/HOS/Services/Vi/ViServer.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Vi/ViServer.cs
@@ -1,0 +1,234 @@
+﻿using Ryujinx.Common;
+using Ryujinx.Graphics.Gpu;
+using Ryujinx.HLE.HOS.Kernel;
+using Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvMap;
+using Ryujinx.HLE.HOS.Services.SurfaceFlinger;
+using Ryujinx.HLE.HOS.Services.SurfaceFlinger.Types;
+using Ryujinx.HLE.HOS.Services.Vi.Types;
+using System.Runtime.CompilerServices;
+
+namespace Ryujinx.HLE.HOS.Services
+{
+    class ViServer : ServerBase
+    {
+        private const int TotalFramebuffers = 16;
+
+        private SurfaceFlinger.SurfaceFlinger _surfaceFlinger;
+
+        private readonly uint _fbWidth;
+        private readonly uint _fbHeight;
+        private readonly PixelFormat _fbFormat;
+        private readonly int _fbUsage;
+        private readonly uint _fbCount;
+        private uint _fbSlotsRequested;
+
+        private ulong _pid;
+        private ulong _fbsBaseAddress;
+        private int _bufferNvMapId;
+        private SharedBufferMap _bufferMap;
+        private long _sharedLayerId;
+
+        public ViServer(KernelContext context, string name) : base(context, name)
+        {
+            _fbWidth = 1280;
+            _fbHeight = 720;
+            _fbFormat = PixelFormat.Rgba8888;
+            _fbUsage = 0x100 | 0x200 | 0x800;
+            _fbCount = 4;
+        }
+
+        protected override ulong CalculateRequiredHeapSize()
+        {
+            return GetSharedBufferSize();
+        }
+
+        protected override void CustomInit(KernelContext context, ulong pid, ulong heapAddress)
+        {
+            _pid = pid;
+            _fbsBaseAddress = heapAddress;
+
+            context.Device.Gpu.RegisterProcess(pid, KernelStatic.GetCurrentProcess().CpuMemory);
+
+            ulong bufferSize = CalculateFramebufferSize();
+            ulong totalSize = bufferSize * TotalFramebuffers;
+
+            KernelStatic.GetCurrentProcess().CpuMemory.Fill(heapAddress, totalSize, 0xff);
+
+            int mapId = NvMapDeviceFile.CreateMap(pid, heapAddress, (uint)totalSize);
+
+            _bufferNvMapId = mapId;
+            _bufferMap.Count = TotalFramebuffers;
+
+            ulong offset = 0;
+
+            for (int i = 0; i < TotalFramebuffers; i++)
+            {
+                _bufferMap.SharedBuffers[i].Offset = offset;
+                _bufferMap.SharedBuffers[i].Size = bufferSize;
+                _bufferMap.SharedBuffers[i].Width = _fbWidth;
+                _bufferMap.SharedBuffers[i].Height = _fbHeight;
+
+                offset += bufferSize;
+            }
+
+            _surfaceFlinger = context.Device.System.SurfaceFlinger;
+            _surfaceFlinger.CreateLayer(out _sharedLayerId, pid);
+        }
+
+        public void OpenSharedLayer(long layerId)
+        {
+            _surfaceFlinger.OpenLayer(_pid, layerId, out _);
+        }
+
+        public void CloseSharedLayer(long layerId)
+        {
+            _surfaceFlinger.CloseLayer(layerId);
+        }
+
+        public void ConnectSharedLayer(long layerId)
+        {
+            var producer = _surfaceFlinger.GetProducerByLayerId(layerId);
+
+            producer.Connect(null, NativeWindowApi.NVN, false, out var output);
+
+            GraphicBuffer graphicBuffer = new GraphicBuffer();
+
+            int gobHeightLog2 = 4;
+            int blockHeight = 8 * (1 << gobHeightLog2);
+            uint widthAlignedBytes = BitUtils.AlignUp(_fbWidth * 4, 64u);
+            uint widthAligned = widthAlignedBytes / 4;
+            uint heightAligned = BitUtils.AlignUp(_fbHeight, (uint)blockHeight);
+            uint totalSize = widthAlignedBytes * heightAligned;
+
+            graphicBuffer.Header.Magic = 0x47424652;
+            graphicBuffer.Header.Width = (int)_fbWidth;
+            graphicBuffer.Header.Height = (int)_fbHeight;
+            graphicBuffer.Header.Stride = (int)widthAligned;
+            graphicBuffer.Header.Format = _fbFormat;
+            graphicBuffer.Header.Usage = _fbUsage;
+            graphicBuffer.Header.IntsCount = (Unsafe.SizeOf<GraphicBuffer>() - Unsafe.SizeOf<GraphicBufferHeader>()) / sizeof(int);
+            graphicBuffer.Buffer.NvMapId = _bufferNvMapId;
+            graphicBuffer.Buffer.Magic = unchecked((int)0xDAFFCAFF);
+            graphicBuffer.Buffer.Pid = 42;
+            graphicBuffer.Buffer.Usage = _fbUsage;
+            graphicBuffer.Buffer.PixelFormat = (int)_fbFormat;
+            graphicBuffer.Buffer.ExternalPixelFormat = (int)_fbFormat;
+            graphicBuffer.Buffer.Stride = (int)widthAligned;
+            graphicBuffer.Buffer.FrameBufferSize = (int)totalSize;
+            graphicBuffer.Buffer.PlanesCount = 1;
+            graphicBuffer.Buffer.Surfaces[0].Width = _fbWidth;
+            graphicBuffer.Buffer.Surfaces[0].Height = _fbHeight;
+            graphicBuffer.Buffer.Surfaces[0].ColorFormat = ColorFormat.A8B8G8R8;
+            graphicBuffer.Buffer.Surfaces[0].Layout = 3; // Block linear
+            graphicBuffer.Buffer.Surfaces[0].Pitch = (int)widthAlignedBytes;
+            graphicBuffer.Buffer.Surfaces[0].Kind = 0xfe; // Generic 16Bx2
+            graphicBuffer.Buffer.Surfaces[0].BlockHeightLog2 = gobHeightLog2;
+            graphicBuffer.Buffer.Surfaces[0].Size = (int)totalSize;
+
+            for (int slot = 0; slot < _fbCount; slot++)
+            {
+                graphicBuffer.Buffer.Surfaces[0].Offset = slot * (int)totalSize;
+
+                producer.SetPreallocatedBuffer(slot, new AndroidStrongPointer<GraphicBuffer>(graphicBuffer));
+            }
+
+            _fbSlotsRequested = 0;
+        }
+
+        public void DisconnectSharedLayer(long layerId)
+        {
+            var producer = _surfaceFlinger.GetProducerByLayerId(layerId);
+
+            producer.Disconnect(NativeWindowApi.NVN);
+        }
+
+        public int DequeueFrameBuffer(long layerId, out AndroidFence fence)
+        {
+            var producer = _surfaceFlinger.GetProducerByLayerId(layerId);
+
+            Status status = producer.DequeueBuffer(out int slot, out fence, false, _fbWidth, _fbHeight, _fbFormat, (uint)_fbUsage);
+
+            if (status == Status.Success)
+            {
+                if ((_fbSlotsRequested & (1u << slot)) == 0)
+                {
+                    status = producer.RequestBuffer(slot, out _);
+
+                    if (status != Status.Success)
+                    {
+                        producer.CancelBuffer(slot, ref fence);
+                    }
+
+                    _fbSlotsRequested |= 1u << slot;
+                }
+            }
+
+            return slot;
+        }
+
+        public void QueueFrameBuffer(long layerId, int slot, Rect crop, NativeWindowTransform transform, int swapInterval, AndroidFence fence)
+        {
+            var producer = _surfaceFlinger.GetProducerByLayerId(layerId);
+
+            var input = new IGraphicBufferProducer.QueueBufferInput();
+
+            input.Crop = crop;
+            input.Transform = transform;
+            input.SwapInterval = swapInterval;
+            input.Fence = fence;
+
+            Status status = producer.QueueBuffer(slot, ref input, out _);
+        }
+
+        public void CancelFrameBuffer(long layerId, int slot)
+        {
+            var producer = _surfaceFlinger.GetProducerByLayerId(layerId);
+            AndroidFence fence = default;
+
+            producer.CancelBuffer(slot, ref fence);
+        }
+
+        public int GetFrameBufferMapIndex(int index)
+        {
+            return (uint)index < _fbCount ? index : 0;
+        }
+
+        public int GetSharedBufferNvMapId()
+        {
+            return _bufferNvMapId;
+        }
+
+        public ulong GetSharedBufferSize()
+        {
+            return CalculateFramebufferSize() * TotalFramebuffers;
+        }
+
+        public long GetSharedLayerId()
+        {
+            return _sharedLayerId;
+        }
+
+        private ulong CalculateFramebufferSize()
+        {
+            // Each GOB dimension is 512 bytes x 8 lines.
+            // Assume 16 GOBs, for a total of 16 x 8 = 128 lines.
+            return BitUtils.AlignUp(_fbWidth * 4, 512u) * BitUtils.AlignUp(_fbHeight, 128u);
+        }
+
+        public SharedBufferMap GetSharedBufferMap()
+        {
+            return _bufferMap;
+        }
+
+        public int GetApplicationLastPresentedFrameHandle(GpuContext gpuContext)
+        {
+            var texture = gpuContext.Window.GetLastPresentedData();
+            var selfAs = KernelStatic.GetProcessByPid(_pid).CpuMemory;
+            int fbIndex = (int)_fbCount; // Place it after all our frame buffers.
+
+            selfAs.Write(_fbsBaseAddress + _bufferMap.SharedBuffers[fbIndex].Offset, texture.Data);
+
+            return fbIndex;
+        }
+    }
+}

--- a/src/Ryujinx.Memory/IVirtualMemoryManagerTracked.cs
+++ b/src/Ryujinx.Memory/IVirtualMemoryManagerTracked.cs
@@ -3,7 +3,7 @@ using Ryujinx.Memory.Tracking;
 using System;
 using System.Collections.Generic;
 
-namespace Ryujinx.Cpu
+namespace Ryujinx.Memory
 {
     public interface IVirtualMemoryManagerTracked : IVirtualMemoryManager
     {


### PR DESCRIPTION
This PR adds the following things:
Gdkchan/Buffer Sharing (Rebased):
Enables buffer sharing, which is essential for rendering newer applets correctly without them crashing.

IHid LastActiveNpad Implementation:
Properly implements the IHid LastActiveNpad, preventing crashes when no controller is connected, the previous implementation of LastActiveNpad also caused crashes when used in specific areas of applets.

Surface Flinger Shared Layers:
Introduces support for multiple rendering layers. 