### PR TITLE
Man...

### DIFF
--- a/src/ARMeilleure/Translation/Cache/JitCache.cs
+++ b/src/ARMeilleure/Translation/Cache/JitCache.cs
@@ -186,7 +186,7 @@ namespace ARMeilleure.Translation.Cache
             
             int newRegionNumber = _activeRegionIndex;
 
-            Logger.Warning?.Print(LogClass.Cpu, $"JIT Cache Region {exhaustedRegion} exhausted, creating new Cache Region {newRegionNumber} ({((newRegionNumber + 1) * CacheSize).Bytes()} Total Allocation).");
+            Logger.Warning?.Print(LogClass.Cpu, $"JIT Cache Region {exhaustedRegion} exhausted, creating new Cache Region {newRegionNumber} ({((long)(newRegionNumber + 1) * CacheSize).Bytes()} Total Allocation).");
         
             _cacheAllocator = new CacheMemoryAllocator(CacheSize);
 

--- a/src/Ryujinx.Cpu/LightningJit/Cache/JitCache.cs
+++ b/src/Ryujinx.Cpu/LightningJit/Cache/JitCache.cs
@@ -166,7 +166,7 @@ namespace Ryujinx.Cpu.LightningJit.Cache
             
             int newRegionNumber = _activeRegionIndex;
 
-            Logger.Warning?.Print(LogClass.Cpu, $"JIT Cache Region {exhaustedRegion} exhausted, creating new Cache Region {newRegionNumber} ({((newRegionNumber + 1) * CacheSize).Bytes()} Total Allocation).");
+            Logger.Warning?.Print(LogClass.Cpu, $"JIT Cache Region {exhaustedRegion} exhausted, creating new Cache Region {newRegionNumber} ({((long)(newRegionNumber + 1) * CacheSize).Bytes()} Total Allocation).");
         
             _cacheAllocator = new CacheMemoryAllocator(CacheSize);
 

--- a/src/Ryujinx/Assets/locales.json
+++ b/src/Ryujinx/Assets/locales.json
@@ -4621,7 +4621,7 @@
         "zh_CN": "繁体中文（推荐）",
         "zh_TW": "正體中文 (建議)"
       }
-    },    
+    },
     {
       "ID": "SettingsTabSystemSystemLanguageSwedish",
       "Translations": {
@@ -4646,7 +4646,7 @@
         "zh_CN": "瑞典语",
         "zh_TW": ""
       }
-    },    
+    },
     {
       "ID": "SettingsTabSystemSystemLanguageNorwegian",
       "Translations": {


### PR DESCRIPTION
Changes it so we use a (long) when calculating how many bytes of total Jit Cache Region is allocated.

Anyway-

If you wanna know why:
![image](https://github.com/user-attachments/assets/5820ce7b-cbfe-4908-8f5e-7ee82040ee1a)

