### PR TITLE
Improved interaction with "Input" settings.

### DIFF
--- a/src/Ryujinx/Assets/Styles/Styles.xaml
+++ b/src/Ryujinx/Assets/Styles/Styles.xaml
@@ -1,8 +1,8 @@
-﻿<Styles
+<Styles
     xmlns="https://github.com/avaloniaui"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:ui="clr-namespace:FluentAvalonia.UI.Controls;assembly=FluentAvalonia"
-    xmlns:windowing="clr-namespace:FluentAvalonia.UI.Windowing;assembly=FluentAvalonia">
+    xmlns:windowing="clr-namespace:FluentAvalonia.UI.Windowing;assembly=FluentAvalonia">   
     <Design.PreviewWith>
         <Border Height="2000"
                 Padding="20">
@@ -41,7 +41,7 @@
                     </StackPanel>
                 </Grid>
                 <ui:NumberBox Value="1" />
-            </StackPanel>
+                </StackPanel>
         </Border>
     </Design.PreviewWith>
     <Style Selector="DropDownButton">
@@ -330,6 +330,15 @@
     <Style Selector="CheckBox TextBlock">
         <Setter Property="Margin"
                 Value="0,5,0,0" />
+    </Style>
+    <Style Selector="TextBlock.pending" >
+        <Setter Property="Foreground" Value="SlateGray"/>
+        <Setter Property="VerticalAlignment" Value="Center"/>
+        <Setter Property="HorizontalAlignment" Value="Left"/>
+        <Setter Property="FontSize" Value="12"/>
+        <Setter Property="Text" Value="(pending!)"/>
+    </Style>
+    <Style Selector="StackPanel.globalConfigMarker">
     </Style>
     <Style Selector="ContextMenu">
         <Setter Property="BorderBrush"

--- a/src/Ryujinx/Assets/locales.json
+++ b/src/Ryujinx/Assets/locales.json
@@ -7073,6 +7073,81 @@
       }
     },
     {
+      "ID": "ControllerSettingsModifiedNotification",
+      "Translations": {
+        "ar_SA": "(تم التعديل!)",
+        "de_DE": "(modifiziert!)",
+        "el_GR": "(τροποποιημένο!)",
+        "en_US": "(Modified!)",
+        "es_ES": "(modificado!)",
+        "fr_FR": "(modifié!)",
+        "he_IL": "(שונה!)",
+        "it_IT": "(modificato!)",
+        "ja_JP": "(変更済み!)",
+        "ko_KR": "(수정됨!)",
+        "no_NO": "(modifisert!)",
+        "pl_PL": "(zmodyfikowane!)",
+        "pt_BR": "(modificado!)",
+        "ru_RU": "(изменено!)",
+        "sv_SE": "(ändrad!)",
+        "th_TH": "(แก้ไขแล้ว!)",
+        "tr_TR": "(değiştirildi!)",
+        "uk_UA": "(модифіковано!)",
+        "zh_CN": "(已修改!)",
+        "zh_TW": "(已修改!)"
+      }
+    },
+    {
+      "ID": "ControllerSettingsDisableDeviceForSaving",
+      "Translations": {
+        "ar_SA": "تم إعداد التحكم.\n\nفي انتظار اتصال وحدة التحكم...",
+        "de_DE": "Steuerung konfiguriert.\n\nWarten auf die Verbindung des Controllers...",
+        "el_GR": "Η διαχείριση έχει ρυθμιστεί.\n\nΑναμένεται σύνδεση του χειριστηρίου...",
+        "en_US": "Control configured.\n\nWaiting for controller connection...",
+        "es_ES": "Control configurado.\n\nEsperando la conexión del controlador...",
+        "fr_FR": "Contrôle configuré.\n\nEn attente de la connexion du contrôleur...",
+        "he_IL": "השליטה הוגדרה.\n\nממתין לחיבור הבקר...",
+        "it_IT": "Controllo configurato.\n\nIn attesa della connessione del controller...",
+        "ja_JP": "コントロールが設定されました。\n\nコントローラーの接続を待っています...",
+        "ko_KR": "제어가 설정되었습니다.\n\n컨트롤러 연결 대기 중...",
+        "no_NO": "Kontroll konfigurert.\n\nVenter på tilkobling av kontroller...",
+        "pl_PL": "Sterowanie skonfigurowane.\n\nOczekiwanie na połączenie kontrolera...",
+        "pt_BR": "Controle configurado.\n\nAguardando conexão do controle...",
+        "ru_RU": "Управление настроено.\n\nОжидается подключение контроллера...",
+        "sv_SE": "Kontroll konfigurerad.\n\nVäntar på anslutning av kontrollen...",
+        "th_TH": "การควบคุมได้รับการตั้งค่าแล้ว\n\nกำลังรอการเชื่อมต่อคอนโทรลเลอร์...",
+        "tr_TR": "Kontrol yapılandırıldı.\n\nKontrolcü bağlantısı bekleniyor...",
+        "uk_UA": "Керування налаштовано.\n\nОчікується підключення контролера...",
+        "zh_CN": "控制已配置。\n\n等待控制器连接...",
+        "zh_TW": "控制已設定。\n\n等待控制器連接..."
+      }
+    },
+    {
+      "ID": "ControllerSettingsUnlink",
+      "Translations": {
+        "ar_SA": "إلغاء الربط",
+        "de_DE": "Entkoppeln",
+        "el_GR": "Αποσύνδεση",
+        "en_US": "Unlink",
+        "es_ES": "Desvincular",
+        "fr_FR": "Dissocier",
+        "he_IL": "ניתוק קישור",
+        "it_IT": "Scollega",
+        "ja_JP": "リンク解除",
+        "ko_KR": "연결 해제",
+        "no_NO": "Frakoble",
+        "pl_PL": "Odłącz",
+        "pt_BR": "Desvincular",
+        "ru_RU": "Отвязать",
+        "sv_SE": "Koppla från",
+        "th_TH": "ยกเลิกการเชื่อมโยง",
+        "tr_TR": "Bağlantıyı Kes",
+        "uk_UA": "Відв'язати",
+        "zh_CN": "解除绑定",
+        "zh_TW": "解除綁定"
+      }
+    },
+    {
       "ID": "ControllerSettingsRemove",
       "Translations": {
         "ar_SA": "إزالة",
@@ -11720,6 +11795,31 @@
         "uk_UA": "Зберегти профіль",
         "zh_CN": "保存配置文件",
         "zh_TW": "儲存設定檔"
+      }
+    },
+    {
+      "ID": "ControllerSettingsCancelCurrentChangesToolTip",
+      "Translations": {
+        "ar_SA": "إلغاء التغييرات الحالية",
+        "de_DE": "Aktuelle Änderungen abbrechen",
+        "el_GR": "Ακύρωση τρεχουσών αλλαγών",
+        "en_US": "Cancel current changes",
+        "es_ES": "Cancelar los cambios actuales",
+        "fr_FR": "Annuler les modifications en cours",
+        "he_IL": "ביטול השינויים הנוכחיים",
+        "it_IT": "Annulla le modifiche correnti",
+        "ja_JP": "現在の変更をキャンセル",
+        "ko_KR": "현재 변경 취소",
+        "no_NO": "Avbryt gjeldende endringer",
+        "pl_PL": "Anuluj bieżące zmiany",
+        "pt_BR": "Cancelar alterações atuais",
+        "ru_RU": "Отменить текущие изменения",
+        "sv_SE": "Avbryt aktuella ändringar",
+        "th_TH": "ยกเลิกการเปลี่ยนแปลงปัจจุบัน",
+        "tr_TR": "Geçerli değişiklikleri iptal et",
+        "uk_UA": "Скасувати поточні зміни",
+        "zh_CN": "取消当前更改",
+        "zh_TW": "取消當前變更"
       }
     },
     {

--- a/src/Ryujinx/UI/ViewModels/Input/ControllerInputViewModel.cs
+++ b/src/Ryujinx/UI/ViewModels/Input/ControllerInputViewModel.cs
@@ -68,18 +68,21 @@ namespace Ryujinx.Ava.UI.ViewModels.Input
         }
 
         public async void ShowMotionConfig()
-        {
+        {      
             await MotionInputView.Show(this);
+            ParentModel.IsModified = true;
         }
 
         public async void ShowRumbleConfig()
-        {
+        {        
             await RumbleInputView.Show(this);
+            ParentModel.IsModified = true;
         }
         
         public async void ShowLedConfig()
         {
             await LedInputView.Show(this);
+            ParentModel.IsModified = true;
         }
 
         public void OnParentModelChanged()

--- a/src/Ryujinx/UI/Views/Input/ControllerInputView.axaml.cs
+++ b/src/Ryujinx/UI/Views/Input/ControllerInputView.axaml.cs
@@ -63,8 +63,9 @@ namespace Ryujinx.Ava.UI.Views.Input
                 };
 
                 if (!float.IsNaN(_changeSlider) && _changeSlider != (float)check.Value)
-                {
-                    (DataContext as ControllerInputViewModel)!.ParentModel.IsModified = true;
+                {     
+                    FlagInputConfigChanged();
+
                     _changeSlider = (float)check.Value;
                 }
             }
@@ -74,7 +75,8 @@ namespace Ryujinx.Ava.UI.Views.Input
         {
             if (sender is CheckBox { IsPointerOver: true })
             {
-                (DataContext as ControllerInputViewModel)!.ParentModel.IsModified = true;
+                FlagInputConfigChanged();
+
                 _currentAssigner?.Cancel();
                 _currentAssigner = null;
             }
@@ -101,7 +103,7 @@ namespace Ryujinx.Ava.UI.Views.Input
                         this.Focus(NavigationMethod.Pointer);
 
                         PointerPressed += MouseClick;
-
+                       
                         ControllerInputViewModel viewModel = (DataContext as ControllerInputViewModel);
 
                         IKeyboard keyboard =
@@ -114,7 +116,7 @@ namespace Ryujinx.Ava.UI.Views.Input
                             if (e.ButtonValue.HasValue)
                             {
                                 Button buttonValue = e.ButtonValue.Value;
-                                viewModel.ParentModel.IsModified = true;
+                                FlagInputConfigChanged();
 
                                 switch (button.Name)
                                 {
@@ -208,6 +210,11 @@ namespace Ryujinx.Ava.UI.Views.Input
             }
         }
 
+        private void FlagInputConfigChanged()
+        {
+            (DataContext as ControllerInputViewModel)!.ParentModel.IsModified = true;
+        }
+
         private void MouseClick(object sender, PointerPressedEventArgs e)
         {
             bool shouldUnbind = e.GetCurrentPoint(this).Properties.IsMiddleButtonPressed;
@@ -239,7 +246,6 @@ namespace Ryujinx.Ava.UI.Views.Input
             {
                 gamepad?.ClearLed();
             }
-            
             _currentAssigner?.Cancel();
             _currentAssigner = null;
         }

--- a/src/Ryujinx/UI/Views/Input/InputView.axaml
+++ b/src/Ryujinx/UI/Views/Input/InputView.axaml
@@ -50,13 +50,21 @@
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto"/>
                         <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
-                    <TextBlock
+                    <StackPanel 
+                        Orientation="Vertical"                             
                         Margin="5,0,10,0"
-                        Width="90"
                         HorizontalAlignment="Left"
                         VerticalAlignment="Center"
-                        Text="{ext:Locale ControllerSettingsPlayer}" />
+                        Width="90">
+                        <TextBlock
+                            Text="{ext:Locale ControllerSettingsPlayer}" />
+                         <TextBlock                        
+                            Classes="pending" 
+                            Text ="{ext:Locale ControllerSettingsModifiedNotification}"
+                            IsVisible="{Binding IsModified}"/>
+                    </StackPanel>
                     <ComboBox
                         Grid.Column="1"
                         Name="PlayerIndexBox"
@@ -71,6 +79,18 @@
                             </DataTemplate>
                         </ComboBox.ItemTemplate>
                     </ComboBox>
+                    <Button
+                        Grid.Column="2"
+                            MinWidth="0"
+                            Margin="5,0,0,0"
+                            VerticalAlignment="Center"
+                            ToolTip.Tip="{ext:Locale ControllerSettingsCancelCurrentChangesToolTip}"
+                            Command="{Binding LoadSavedConfiguration}">
+                        <ui:SymbolIcon
+                            Symbol="Cancel"
+                            FontSize="15"
+                            Height="20" />
+                    </Button>
                 </Grid>
                 <!-- Profile Selection -->
                 <Grid
@@ -174,7 +194,7 @@
                         MinWidth="0"
                         Margin="5,0,0,0"
                         VerticalAlignment="Center"
-                        Command="{Binding LoadDevices}">
+                        Command="{Binding LoadDevice}">
                         <ui:SymbolIcon
                             Symbol="Refresh"
                             FontSize="15"
@@ -211,15 +231,37 @@
                 </Grid>
             </Grid>
         </StackPanel>
-        <ContentControl Content="{Binding ConfigViewModel}" IsVisible="{Binding ShowSettings}">
-            <ContentControl.DataTemplates>
-                <DataTemplate DataType="viewModels:ControllerInputViewModel">
-                    <views:ControllerInputView />
-                </DataTemplate>
-                <DataTemplate DataType="viewModels:KeyboardInputViewModel">
-                    <views:KeyboardInputView />
-                </DataTemplate>
-            </ContentControl.DataTemplates>
+        <ContentControl IsVisible="{Binding NotificationView}">
+            <ContentControl.Content>
+                <StackPanel>
+                    <TextBlock 
+                        Margin="5,20,0,0"
+                        Text="{ext:Locale ControllerSettingsDisableDeviceForSaving}" />
+        
+                    <Button
+                        MinWidth="0"
+                        Width="90"
+                        Height="27"
+                        Margin="5,10,0,0"
+                        VerticalAlignment="Center"
+                        Command="{Binding DisableDeviceForSaving}">
+                        <TextBlock
+                            Text="{ext:Locale ControllerSettingsUnlink}"
+                            VerticalAlignment="Center"
+                            HorizontalAlignment="Center" />
+                    </Button>
+                </StackPanel>
+            </ContentControl.Content>
         </ContentControl>
+            <ContentControl Content="{Binding ConfigViewModel}" IsVisible="{Binding ShowSettings}">        
+                <ContentControl.DataTemplates>
+                    <DataTemplate DataType="viewModels:ControllerInputViewModel">
+                        <views:ControllerInputView />
+                    </DataTemplate>
+                    <DataTemplate DataType="viewModels:KeyboardInputViewModel">
+                        <views:KeyboardInputView />
+                    </DataTemplate>
+                </ContentControl.DataTemplates>
+            </ContentControl>
     </StackPanel>
 </UserControl>

--- a/src/Ryujinx/UI/Views/Input/InputView.axaml.cs
+++ b/src/Ryujinx/UI/Views/Input/InputView.axaml.cs
@@ -62,13 +62,14 @@ namespace Ryujinx.Ava.UI.Views.Input
                     }
                     return;
                 }
-                
-                ViewModel.PlayerId = ViewModel.PlayerIdChoose;
 
                 ViewModel.IsModified = false;
+                ViewModel.PlayerId = ViewModel.PlayerIdChoose;
+                               
             }
             
         }
+
 
         public void Dispose()
         {

--- a/src/Ryujinx/UI/Views/Input/KeyboardInputView.axaml.cs
+++ b/src/Ryujinx/UI/Views/Input/KeyboardInputView.axaml.cs
@@ -73,7 +73,7 @@ namespace Ryujinx.Ava.UI.Views.Input
                         if (e.ButtonValue.HasValue)
                         {
                             Button buttonValue = e.ButtonValue.Value;
-                            viewModel.ParentModel.IsModified = true;
+                            FlagInputConfigChanged();
 
                             switch (button.Name)
                             {
@@ -182,6 +182,11 @@ namespace Ryujinx.Ava.UI.Views.Input
                 _currentAssigner?.Cancel();
                 _currentAssigner = null;
             }
+        }
+
+        private void FlagInputConfigChanged()
+        {
+            (DataContext as KeyboardInputViewModel)!.ParentModel.IsModified = true;
         }
 
         private void MouseClick(object sender, PointerPressedEventArgs e)


### PR DESCRIPTION
I made some fixes to the settings input section.

Changes and fixes:

- Paired devices have notifications that they are configured and require connection
- Paired devices load the configuration when connected
- A notification appears when changing control configuration settings.
- Now control settings will be saved only when they are changed
- Added a button to roll back changes to the previous saved state
- Fixed a bug: when switching the "player", if the "input device" and "controller type" settings were changed, the save dialog box did not appear.
- "Motion", "Rumble" and "Led" also have events notifying about changes

https://github.com/user-attachments/assets/e760b4bd-15a3-49da-a395-0beb64301548


**Please note: the current pull request does not solve the problem with connecting the gamepad after rebooting the emulator! There is a separate topic for this**