### PR TITLE
Jit regions fix

### DIFF
--- a/src/ARMeilleure/Translation/Cache/JitUnwindWindows.cs
+++ b/src/ARMeilleure/Translation/Cache/JitUnwindWindows.cs
@@ -52,6 +52,11 @@ namespace ARMeilleure.Translation.Cache
             nint context,
             [MarshalAs(UnmanagedType.LPWStr)] string outOfProcessCallbackDll);
 
+        [LibraryImport("kernel32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static unsafe partial bool RtlDeleteFunctionTable(
+            ulong tableIdentifier);
+
         private static GetRuntimeFunctionCallback _getRuntimeFunctionCallback;
 
         private static int _sizeOfRuntimeFunction;
@@ -88,6 +93,23 @@ namespace ARMeilleure.Translation.Cache
             if (!result)
             {
                 throw new InvalidOperationException("Failure installing function table callback.");
+            }
+        }
+
+        public static void RemoveFunctionTableHandler(nint codeCachePointer)
+        {
+            ulong codeCachePtr = (ulong)codeCachePointer.ToInt64();
+
+            bool result;
+
+            unsafe
+            {
+                result = RtlDeleteFunctionTable(codeCachePtr | 3);
+            }
+
+            if (!result)
+            {
+                throw new InvalidOperationException("Failure removing function table callback.");
             }
         }
 

--- a/src/Ryujinx/UI/Controls/ApplicationContextMenu.axaml.cs
+++ b/src/Ryujinx/UI/Controls/ApplicationContextMenu.axaml.cs
@@ -200,7 +200,7 @@ namespace Ryujinx.Ava.UI.Controls
                 if (backupDir.Exists)
                 {
                     cacheFiles.AddRange(backupDir.EnumerateFiles("*.cache"));
-                    cacheFiles.AddRange(mainDir.EnumerateFiles("*.info"));
+                    cacheFiles.AddRange(backupDir.EnumerateFiles("*.info"));
                 }
 
                 if (cacheFiles.Count > 0)


### PR DESCRIPTION
Jit cache now fully resets when booting a game multiple times.
This should fix random jit cache crashes.
Also removed some redundant code related to region allocation and fixed PPTC Purge not fully purging all PPTC files in the backup folder.