### PR TITLE
Remove 'About Avalonia' and Replace it with 'About Ryujinx' in MacOS's menu bar

### DIFF
--- a/src/Ryujinx/RyujinxApp.axaml
+++ b/src/Ryujinx/RyujinxApp.axaml
@@ -17,4 +17,9 @@
         <sty:FluentAvaloniaTheme PreferUserAccentColor="True" PreferSystemTheme="False" />
         <StyleInclude Source="/Assets/Styles/Styles.xaml" />
     </Application.Styles>
+    <NativeMenu.Menu>
+        <NativeMenu>
+            <NativeMenuItem Header="About Ryujinx" Click="AboutRyujinx_OnClick" />
+        </NativeMenu>
+    </NativeMenu.Menu>
 </Application>

--- a/src/Ryujinx/RyujinxApp.axaml.cs
+++ b/src/Ryujinx/RyujinxApp.axaml.cs
@@ -147,5 +147,10 @@ namespace Ryujinx.Ava
             Current is RyujinxApp { PlatformSettings: not null } app
                 ? ConvertThemeVariant(app.PlatformSettings.GetColorValues().ThemeVariant)
                 : ThemeVariant.Default;
+
+        private async void AboutRyujinx_OnClick(object sender, EventArgs e)
+        {
+            await AboutWindow.Show();
+        }
     }
 }


### PR DESCRIPTION
Video demonstration for my windows users out there (greem): https://www.youtube.com/watch?v=7Wn_k5AjBuU