### PR TITLE
sdl2 guid, remove the 2 CRC bytes when creating guid

### DIFF
--- a/src/Ryujinx.Input.SDL2/SDL2GamepadDriver.cs
+++ b/src/Ryujinx.Input.SDL2/SDL2GamepadDriver.cs
@@ -50,6 +50,9 @@ namespace Ryujinx.Input.SDL2
         {
             Guid guid = SDL_JoystickGetDeviceGUID(joystickIndex);
 
+            // Remove the first 4 char of the guid (CRC part) to make it stable
+            string guidString = "0000" + guid.ToString().Substring(4);
+
             // Add a unique identifier to the start of the GUID in case of duplicates.
 
             if (guid == Guid.Empty)
@@ -62,11 +65,11 @@ namespace Ryujinx.Input.SDL2
             lock (_lock)
             {
                 int guidIndex = 0;
-                id = guidIndex + "-" + guid;
+                id = guidIndex + "-" + guidString;
 
                 while (_gamepadsIds.Contains(id))
                 {
-                    id = (++guidIndex) + "-" + guid;
+                    id = (++guidIndex) + "-" + guidString;
                 }
             }
 


### PR DESCRIPTION
This change fixes issues with controllers changing guid changing with every launch by removing the 4 first chars (crc16) used by SDL that change with every init for xbox controllers.

Fix #751
Fix #687 
Fix #577 